### PR TITLE
Fix: Using correct unit for Postgres CloudSQL Volume size

### DIFF
--- a/modules/postgres/cloudsql/0.2/facets.yaml
+++ b/modules/postgres/cloudsql/0.2/facets.yaml
@@ -59,9 +59,9 @@ spec:
               type: string
               title: Volume
               description: The size of the volume.
-              pattern: "^[0-9]+(\\.[0-9]+)?[EiKMGTP]i?$"
-              x-ui-placeholder: "e.g., '10Gi'"
-              x-ui-error-message: "Please specify the volume size in the correct format (e.g., '10Gi')."
+              pattern: "^[0-9]+(\\.[0-9]+)?[G]?$"
+              x-ui-placeholder: "e.g., '10G'"
+              x-ui-error-message: "Please specify the volume size in the correct format (e.g., '10G')."
           required:
             - instance
             - volume


### PR DESCRIPTION
Task - https://app.clickup.com/t/86cvj18vd

Revised the validation regex to exclusively match the postfix 'G'. Other characters are not permitted because GCP CloudSQL requires the storage size to be specified in GBs.

