### PR TITLE
add cluster code flag in k8s

### DIFF
--- a/templates/base/kubernetes_cluster/instances/default.json
+++ b/templates/base/kubernetes_cluster/instances/default.json
@@ -8,5 +8,10 @@
     "spec": {},
     "provided": false,
     "disabled": false,
-    "inputs": {}
+    "inputs": {},
+    "advanced": {
+        "default": {
+            "include_cluster_code_in_name": true
+        }
+    }
   }


### PR DESCRIPTION
> [!WARNING]  
> merge this **after** Facets-cloud/facets-iac#1122 has been released and tag `3.6.x` is mapped as default for saas