### PR TITLE
add sub path support in service form ui

### DIFF
--- a/modules/service/k8s/0.1/facets.yaml
+++ b/modules/service/k8s/0.1/facets.yaml
@@ -366,7 +366,7 @@ spec:
                   sub_path:
                     type: string
                     title: Sub Path
-                    description: Optional. The path within the ConfigMap to mount a specific key or file
+                    description: Path within the ConfigMap to mount a specific key or file
                 required:
                   - name
                   - mount_path
@@ -390,7 +390,7 @@ spec:
                   sub_path:
                     type: string
                     title: Sub Path
-                    description: Optional. The path within the Secret to mount a specific key or file
+                    description: Path within the Secret to mount a specific key or file
                 required:
                   - name
                   - mount_path
@@ -414,7 +414,7 @@ spec:
                   sub_path:
                     type: string
                     title: Sub Path
-                    description: Optional. The path within the PVC to mount a specific subdirectory
+                    description: Path within the PVC to mount a specific subdirectory
                 required:
                   - claim_name
                   - mount_path
@@ -434,7 +434,7 @@ spec:
                   sub_path:
                     type: string
                     title: Sub Path
-                    description: Optional. The path within the host filesystem to mount a specific directory or file
+                    description: Path within the host filesystem to mount a specific directory or file
                 required:
                   - name
                   - mount_path


### PR DESCRIPTION
> [!NOTE]
>
> merge this after https://github.com/Facets-cloud/facets-iac/pull/1213 has been released (iac tag `3.7`)

- adds support for sub path
- marks some fields as mandatory for volumes
- subtext is added

![image](https://github.com/user-attachments/assets/8489372d-b60b-47b3-8e94-6134ec825d8b)
![image](https://github.com/user-attachments/assets/be0c9ed1-0d18-4270-af77-341b1adad16a)
