### PR TITLE
[CX] Remove regex pattern from integer fields in service/k8s

### DIFF
--- a/index.json
+++ b/index.json
@@ -192,7 +192,6 @@
     "flavor": "k8s",
     "version": "0.1",
     "gitUrl": "https://github.com/Facets-cloud/facets-modules",
-    "gitRef": "integer-field-remove-pattern",
     "relativePath": "./modules/service/k8s/0.1/",
     "clouds": [
       "aws",


### PR DESCRIPTION
# Description

[simplismart found a bug](https://facetscloud.slack.com/archives/C07C54G2WRX/p1728035035948249) in validation of autoscaling min & max fields 
![image](https://github.com/user-attachments/assets/4aa0e3aa-6de3-422e-a054-552b8b645a77)
![image](https://github.com/user-attachments/assets/8e3e46e9-35db-4e88-a101-7683bba1fa15)


This is due to wrong regex pattern being present.
Apart from that the regex pattern is redundant because the field is integer type supporting minimum & maximum checks, which is what all the regex in the diff of this PR aim to validate.

I've removed the same and replaced them with integer field `min`/`max` validations instead

## Related issues
https://app.clickup.com/t/86cwpneqj

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist
<!-- Please delete options that are not relevant. -->

- [x] I have created feat/bugfix branch out of `develop` branch
- [x] Code passes linting/formatting checks
- [x] Changes to resources have been tested in our dev environments
- [ ] I have made corresponding changes to the documentation

## Testing
### Autoscaling field
![image](https://github.com/user-attachments/assets/9aff0642-4114-4a59-8bee-9142b4a79f6f)

### Readiness block
![image](https://github.com/user-attachments/assets/e3c086ba-a70b-4eaa-9c49-a8e3f4699b7a)

### Liveness block
![image](https://github.com/user-attachments/assets/f5405dc4-731d-4d19-bf0d-f66da87ae562)

## Reviewer instructions
<!-- Include any instructions or guidance for reviewers, including specific areas to focus on or areas that require additional attention -->
