### PR TITLE
Set static tempo service account name in template to match the name set in IAM role

### DIFF
--- a/templates/otel_suite/helm/instances/tempo.json
+++ b/templates/otel_suite/helm/instances/tempo.json
@@ -71,7 +71,8 @@
 				"annotations": {
 					"eks.amazonaws.com/role-arn": "${aws_iam_role.tempo-s3-access.out.attributes.irsa_iam_role_arn}"
 				},
-				"automountServiceAccountToken": false
+				"automountServiceAccountToken": false,
+				"name": "tempo"
 			},
 			"rbac": {
 				"create": false,


### PR DESCRIPTION
# Description
When creating the template, if custom name is set, then the service account created when deploying the tempo helm chart will take that custom name.

However in the IAM role created for access to S3 bucket, the service account name is set to `tempo`. 
Hence setting a static name to the tempo's service account as well so no Access Denied issue happens in an out of box launch

## Related issues
<!-- If this PR is related to an existing issue or feature request, please reference clickup task url here. -->

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist
<!-- Please delete options that are not relevant. -->

- [ ] I have created feat/bugfix branch out of `develop` branch
- [ ] Code passes linting/formatting checks
- [ ] Changes to resources have been tested in our dev environments
- [ ] I have made corresponding changes to the documentation

## Testing

<!-- Detail how the changes have been tested, including any automated or manual tests performed. Include the results of the testing (Screenshots, links to releases, etc.), including any issues or bugs encountered and how they were resolved -->

## Reviewer instructions
<!-- Include any instructions or guidance for reviewers, including specific areas to focus on or areas that require additional attention -->
