### PR TITLE
Revert "Revert "add init and sidecar support""

### DIFF
--- a/modules/service/deployment/0.1/facets.yaml
+++ b/modules/service/deployment/0.1/facets.yaml
@@ -803,6 +803,20 @@ spec:
                           type: string
                           title: Name
                           description: Config map name
+                          pattern: "^[a-zA-Z0-9]([a-zA-Z0-9-]{1,18}[a-zA-Z0-9])$"
+                          x-ui-error-message: "Value doesn't match pattern, it should start with an alphanumeric character and should be in range of 3-20 characters"
+                          x-ui-typeable: true
+                          x-ui-api-source:
+                            endpoint: "/cc-ui/v1/dropdown/stack/{{stackName}}/resources-info"
+                            method: GET
+                            params:
+                              includeContent: false
+                            labelKey: resourceName
+                            valueKey: resourceName
+                            valueTemplate: "${config_map.{{value}}.out.attributes.name}"
+                            filterConditions:
+                              - field: resourceType
+                                value: config_map
                         mount_path:
                           type: string
                           title: Mount Path
@@ -827,6 +841,18 @@ spec:
                           type: string
                           title: Name
                           description: Secret name
+                          x-ui-typeable: true
+                          x-ui-api-source:
+                            endpoint: "/cc-ui/v1/dropdown/stack/{{stackName}}/resources-info"
+                            method: GET
+                            params:
+                              includeContent: false
+                            labelKey: resourceName
+                            valueKey: resourceName
+                            valueTemplate: "${kubernetes_secret.{{value}}.out.attributes.name}"
+                            filterConditions:
+                              - field: resourceType
+                                value: kubernetes_secret
                         mount_path:
                           type: string
                           title: Mount Path
@@ -851,6 +877,20 @@ spec:
                           type: string
                           title: Claim Name
                           description: PVC name
+                          pattern: "^[a-zA-Z0-9]([a-zA-Z0-9-]{1,18}[a-zA-Z0-9])$"
+                          x-ui-error-message: "Value doesn't match pattern, it should start with an alphanumeric character and should be in range of 3-20 characters"
+                          x-ui-typeable: true
+                          x-ui-api-source:
+                            endpoint: "/cc-ui/v1/dropdown/stack/{{stackName}}/resources-info"
+                            method: GET
+                            params:
+                              includeContent: false
+                            labelKey: resourceName
+                            valueKey: resourceName
+                            valueTemplate: "${pvc.{{value}}.out.attributes.name}"
+                            filterConditions:
+                              - field: resourceType
+                                value: pvc
                         mount_path:
                           type: string
                           title: Mount Path
@@ -1013,6 +1053,20 @@ spec:
                           type: string
                           title: Name
                           description: Config map name
+                          pattern: "^[a-zA-Z0-9]([a-zA-Z0-9-]{1,18}[a-zA-Z0-9])$"
+                          x-ui-error-message: "Value doesn't match pattern, it should start with an alphanumeric character and should be in range of 3-20 characters"
+                          x-ui-typeable: true
+                          x-ui-api-source:
+                            endpoint: "/cc-ui/v1/dropdown/stack/{{stackName}}/resources-info"
+                            method: GET
+                            params:
+                              includeContent: false
+                            labelKey: resourceName
+                            valueKey: resourceName
+                            valueTemplate: "${config_map.{{value}}.out.attributes.name}"
+                            filterConditions:
+                              - field: resourceType
+                                value: config_map
                         mount_path:
                           type: string
                           title: Mount Path
@@ -1037,6 +1091,18 @@ spec:
                           type: string
                           title: Name
                           description: Secret name
+                          x-ui-typeable: true
+                          x-ui-api-source:
+                            endpoint: "/cc-ui/v1/dropdown/stack/{{stackName}}/resources-info"
+                            method: GET
+                            params:
+                              includeContent: false
+                            labelKey: resourceName
+                            valueKey: resourceName
+                            valueTemplate: "${kubernetes_secret.{{value}}.out.attributes.name}"
+                            filterConditions:
+                              - field: resourceType
+                                value: kubernetes_secret
                         mount_path:
                           type: string
                           title: Mount Path
@@ -1061,6 +1127,20 @@ spec:
                           type: string
                           title: Claim Name
                           description: PVC name
+                          pattern: "^[a-zA-Z0-9]([a-zA-Z0-9-]{1,18}[a-zA-Z0-9])$"
+                          x-ui-error-message: "Value doesn't match pattern, it should start with an alphanumeric character and should be in range of 3-20 characters"
+                          x-ui-typeable: true
+                          x-ui-api-source:
+                            endpoint: "/cc-ui/v1/dropdown/stack/{{stackName}}/resources-info"
+                            method: GET
+                            params:
+                              includeContent: false
+                            labelKey: resourceName
+                            valueKey: resourceName
+                            valueTemplate: "${pvc.{{value}}.out.attributes.name}"
+                            filterConditions:
+                              - field: resourceType
+                                value: pvc
                         mount_path:
                           type: string
                           title: Mount Path

--- a/modules/service/statefulset/0.1/facets.yaml
+++ b/modules/service/statefulset/0.1/facets.yaml
@@ -830,6 +830,20 @@ spec:
                           type: string
                           title: Name
                           description: Config map name
+                          pattern: "^[a-zA-Z0-9]([a-zA-Z0-9-]{1,18}[a-zA-Z0-9])$"
+                          x-ui-error-message: "Value doesn't match pattern, it should start with an alphanumeric character and should be in range of 3-20 characters"
+                          x-ui-typeable: true
+                          x-ui-api-source:
+                            endpoint: "/cc-ui/v1/dropdown/stack/{{stackName}}/resources-info"
+                            method: GET
+                            params:
+                              includeContent: false
+                            labelKey: resourceName
+                            valueKey: resourceName
+                            valueTemplate: "${config_map.{{value}}.out.attributes.name}"
+                            filterConditions:
+                              - field: resourceType
+                                value: config_map
                         mount_path:
                           type: string
                           title: Mount Path
@@ -854,6 +868,18 @@ spec:
                           type: string
                           title: Name
                           description: Secret name
+                          x-ui-typeable: true
+                          x-ui-api-source:
+                            endpoint: "/cc-ui/v1/dropdown/stack/{{stackName}}/resources-info"
+                            method: GET
+                            params:
+                              includeContent: false
+                            labelKey: resourceName
+                            valueKey: resourceName
+                            valueTemplate: "${kubernetes_secret.{{value}}.out.attributes.name}"
+                            filterConditions:
+                              - field: resourceType
+                                value: kubernetes_secret
                         mount_path:
                           type: string
                           title: Mount Path
@@ -878,6 +904,20 @@ spec:
                           type: string
                           title: Claim Name
                           description: PVC name
+                          pattern: "^[a-zA-Z0-9]([a-zA-Z0-9-]{1,18}[a-zA-Z0-9])$"
+                          x-ui-error-message: "Value doesn't match pattern, it should start with an alphanumeric character and should be in range of 3-20 characters"
+                          x-ui-typeable: true
+                          x-ui-api-source:
+                            endpoint: "/cc-ui/v1/dropdown/stack/{{stackName}}/resources-info"
+                            method: GET
+                            params:
+                              includeContent: false
+                            labelKey: resourceName
+                            valueKey: resourceName
+                            valueTemplate: "${pvc.{{value}}.out.attributes.name}"
+                            filterConditions:
+                              - field: resourceType
+                                value: pvc
                         mount_path:
                           type: string
                           title: Mount Path
@@ -1040,6 +1080,20 @@ spec:
                           type: string
                           title: Name
                           description: Config map name
+                          pattern: "^[a-zA-Z0-9]([a-zA-Z0-9-]{1,18}[a-zA-Z0-9])$"
+                          x-ui-error-message: "Value doesn't match pattern, it should start with an alphanumeric character and should be in range of 3-20 characters"
+                          x-ui-typeable: true
+                          x-ui-api-source:
+                            endpoint: "/cc-ui/v1/dropdown/stack/{{stackName}}/resources-info"
+                            method: GET
+                            params:
+                              includeContent: false
+                            labelKey: resourceName
+                            valueKey: resourceName
+                            valueTemplate: "${config_map.{{value}}.out.attributes.name}"
+                            filterConditions:
+                              - field: resourceType
+                                value: config_map
                         mount_path:
                           type: string
                           title: Mount Path
@@ -1064,6 +1118,18 @@ spec:
                           type: string
                           title: Name
                           description: Secret name
+                          x-ui-typeable: true
+                          x-ui-api-source:
+                            endpoint: "/cc-ui/v1/dropdown/stack/{{stackName}}/resources-info"
+                            method: GET
+                            params:
+                              includeContent: false
+                            labelKey: resourceName
+                            valueKey: resourceName
+                            valueTemplate: "${kubernetes_secret.{{value}}.out.attributes.name}"
+                            filterConditions:
+                              - field: resourceType
+                                value: kubernetes_secret
                         mount_path:
                           type: string
                           title: Mount Path
@@ -1088,6 +1154,20 @@ spec:
                           type: string
                           title: Claim Name
                           description: PVC name
+                          pattern: "^[a-zA-Z0-9]([a-zA-Z0-9-]{1,18}[a-zA-Z0-9])$"
+                          x-ui-error-message: "Value doesn't match pattern, it should start with an alphanumeric character and should be in range of 3-20 characters"
+                          x-ui-typeable: true
+                          x-ui-api-source:
+                            endpoint: "/cc-ui/v1/dropdown/stack/{{stackName}}/resources-info"
+                            method: GET
+                            params:
+                              includeContent: false
+                            labelKey: resourceName
+                            valueKey: resourceName
+                            valueTemplate: "${pvc.{{value}}.out.attributes.name}"
+                            filterConditions:
+                              - field: resourceType
+                                value: pvc
                         mount_path:
                           type: string
                           title: Mount Path


### PR DESCRIPTION
Pr conains changes for:
- Reverts Facets-cloud/facets-modules#200
- add x-ui-typeable and dropdown support for init containers volume block from configmap, secret and pvc as added for main container in #203 