### PR TITLE
Add outputs facets.yaml for AWS, Azure, and GCP VPCs

### DIFF
--- a/outputs.index.json
+++ b/outputs.index.json
@@ -163,5 +163,23 @@
     "name": "mongodb_auth_operator",
     "gitUrl": "https://github.com/Facets-cloud/facets-modules",
     "relativePath": "./outputs/mongodb_auth_operator/"
+  },
+  {
+    "name": "azure_vpc",
+    "gitUrl": "https://github.com/Facets-cloud/facets-modules",
+    "relativePath": "./outputs/azure_vpc/",
+    "gitRef": "vpc_outputs"
+  },
+  {
+    "name": "aws_vpc",
+    "gitUrl": "https://github.com/Facets-cloud/facets-modules",
+    "relativePath": "./outputs/aws_vpc/",
+    "gitRef": "vpc_outputs"
+  },
+  {
+    "name": "gcp_vpc",
+    "gitUrl": "https://github.com/Facets-cloud/facets-modules",
+    "relativePath": "./outputs/gcp_vpc/",
+    "gitRef": "vpc_outputs"
   }
 ]

--- a/outputs.index.json
+++ b/outputs.index.json
@@ -167,19 +167,16 @@
   {
     "name": "azure_vpc",
     "gitUrl": "https://github.com/Facets-cloud/facets-modules",
-    "relativePath": "./outputs/azure_vpc/",
-    "gitRef": "vpc_outputs"
+    "relativePath": "./outputs/azure_vpc/"
   },
   {
     "name": "aws_vpc",
     "gitUrl": "https://github.com/Facets-cloud/facets-modules",
-    "relativePath": "./outputs/aws_vpc/",
-    "gitRef": "vpc_outputs"
+    "relativePath": "./outputs/aws_vpc/"
   },
   {
     "name": "gcp_vpc",
     "gitUrl": "https://github.com/Facets-cloud/facets-modules",
-    "relativePath": "./outputs/gcp_vpc/",
-    "gitRef": "vpc_outputs"
+    "relativePath": "./outputs/gcp_vpc/"
   }
 ]

--- a/outputs/aws_vpc/output.facets.yaml
+++ b/outputs/aws_vpc/output.facets.yaml
@@ -1,0 +1,8 @@
+name: aws_vpc
+out:
+  type: object
+  title: AWS VPC
+  description: Outputs from AWS VPC
+  properties:
+    attributes:
+    interfaces:

--- a/outputs/azure_vpc/output.facets.yaml
+++ b/outputs/azure_vpc/output.facets.yaml
@@ -1,0 +1,8 @@
+name: azure_vpc
+out:
+  type: object
+  title: Azure VPC
+  description: Outputs from Azure VPC
+  properties:
+    attributes:
+    interfaces:

--- a/outputs/gcp_vpc/output.facets.yaml
+++ b/outputs/gcp_vpc/output.facets.yaml
@@ -1,0 +1,8 @@
+name: gcp_vpc
+out:
+  type: object
+  title: GCP VPC
+  description: Outputs from GCP VPC
+  properties:
+    attributes:
+    interfaces:


### PR DESCRIPTION
# Description

adds outputs for vpc for all 3 clouds.

This pr will also unblock #248

## Related issues
<!-- If this PR is related to an existing issue or feature request, please reference clickup task url here. -->

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist
<!-- Please delete options that are not relevant. -->

- [ ] I have created feat/bugfix branch out of `develop` branch
- [ ] Code passes linting/formatting checks
- [ ] Changes to resources have been tested in our dev environments
- [ ] I have made corresponding changes to the documentation

## Testing

<!-- Detail how the changes have been tested, including any automated or manual tests performed. Include the results of the testing (Screenshots, links to releases, etc.), including any issues or bugs encountered and how they were resolved -->

## Reviewer instructions
<!-- Include any instructions or guidance for reviewers, including specific areas to focus on or areas that require additional attention -->


