### PR TITLE
disable exposed endpoints in k8s dashboard

### DIFF
--- a/templates/base/ingress/instances/tools.json
+++ b/templates/base/ingress/instances/tools.json
@@ -69,6 +69,26 @@
 					"nginx.ingress.kubernetes.io/backend-protocol": "HTTPS"
 				},
 				"disable_auth": true
+			},
+			"k8s-noop-metrics": {
+				"service_name": "noop-404",
+				"path": "/metrics",
+				"port": 443,
+				"domain_prefix": "k8s",
+				"annotations": {
+					"nginx.ingress.kubernetes.io/backend-protocol": "HTTPS"
+				},
+				"disable_auth": true
+			},
+			"k8s-noop-debug": {
+				"service_name": "noop-404",
+				"path": "/debug",
+				"port": 443,
+				"domain_prefix": "k8s",
+				"annotations": {
+					"nginx.ingress.kubernetes.io/backend-protocol": "HTTPS"
+				},
+				"disable_auth": true
 			}
 		},
 		"force_ssl_redirection": true


### PR DESCRIPTION
# Description
K8s dashboard exposes 2 endpoints `/metrics` & `/debug/vars` which are public, non-configurable and expose potentially sensitive info.

This pr fixes that by routing those endpoints to a service which does not exist

Refer to https://github.com/Facets-cloud/cc-substacks/pull/109 for more info

## Related issues
<!-- If this PR is related to an existing issue or feature request, please reference clickup task url here. -->

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist
<!-- Please delete options that are not relevant. -->

- [ ] I have created feat/bugfix branch out of `develop` branch
- [ ] Code passes linting/formatting checks
- [ ] Changes to resources have been tested in our dev environments
- [ ] I have made corresponding changes to the documentation

## Testing

<!-- Detail how the changes have been tested, including any automated or manual tests performed. Include the results of the testing (Screenshots, links to releases, etc.), including any issues or bugs encountered and how they were resolved -->

## Reviewer instructions
<!-- Include any instructions or guidance for reviewers, including specific areas to focus on or areas that require additional attention -->
