### PR TITLE
add 0.3 version of postgresql user

### DIFF
--- a/index.json
+++ b/index.json
@@ -1647,5 +1647,18 @@
       "azure",
       "kubernetes"
     ]
+  },
+  {
+    "intent": "postgres_user",
+    "flavor": "default",
+    "version": "0.3",
+    "gitUrl": "https://github.com/Facets-cloud/facets-modules",
+    "relativePath": "./modules/postgres_user/default/0.3/",
+    "clouds": [
+      "aws",
+      "gcp",
+      "azure",
+      "kubernetes"
+    ]
   }
 ]

--- a/modules/postgres_user/default/0.3/facets.yaml
+++ b/modules/postgres_user/default/0.3/facets.yaml
@@ -1,0 +1,184 @@
+intent: postgres_user
+flavor: default
+version: "0.3"
+description: Adds postgres_user - default flavor
+clouds:
+  - aws
+  - gcp
+  - azure
+  - kubernetes
+lifecycle: ENVIRONMENT
+input_type: instance
+composition: {}
+inputs:
+  kubernetes_details:
+    type: "@output/kubernetes"
+    displayName: Kubernetes Cluster
+    description: Details of Kubernetes where the CRD for managing postgresql user will be created
+    optional: false
+    default:
+      resource_type: kubernetes_cluster
+      resource_name: default
+  database_operator_details:
+    type: "@output/database_operator"
+    displayName: Database Operator
+    description: Details of database operator which will be responsible to create postgres users
+    optional: false
+  postgres_details:
+    type: "@output/postgres"
+    displayName: Postgres
+    description: Details of Postgres where the user needs to be created
+    optional: false
+spec:
+  title: Postgres User Spec
+  description: Specification for postgres user
+  type: object
+  properties:
+    postgres_user:
+      title: Postgres User
+      description: Specification for postgres user and role
+      type: object
+      properties:
+        role_name:
+          title: Role Name
+          description: Name of role and user to be created in postgres
+          type: string
+        role:
+          title: Role
+          description: Postgres role Specification
+          type: object
+          properties:
+            connection_limit:
+              title: Connection Limit
+              description: Maximum number of connections that can be made to the database using this role
+              type: integer
+              minimum: 1
+            privileges:
+              title: Privileges
+              description: List of privileges that will be granted to the role
+              type: object
+              properties:
+                bypass_rls:
+                  title: Bypass RLS
+                  description: Bypass Row Level Security
+                  type: boolean
+                  default: false
+                create_db:
+                  title: Create DB
+                  description: Create Database
+                  type: boolean
+                  default: false
+                create_role:
+                  title: Create Role
+                  description: Create Role
+                  type: boolean
+                  default: false
+                inherit:
+                  title: Inherit
+                  description: Inherit privileges from other roles
+                  type: boolean
+                  default: false
+                login:
+                  title: Login
+                  description: Login to the database
+                  type: boolean
+                  default: false
+                replication:
+                  title: Replication
+                  description: Replication
+                  type: boolean
+                  default: false
+                superuser:
+                  title: Superuser
+                  description: Superuser
+                  type: boolean
+                  default: false
+        user_password:
+          title: User Password
+          description: Password for the user
+          type: string
+        grant_statements:
+          title: Grant Statements
+          description: Map of PostgreSQL database to grant queries that will be executed to grant permissions after role creation on particular database
+          type: object
+          minProperties: 1
+          patternProperties:
+            keyPattern: "^[a-zA-Z0-9_-]+$"
+            type: object
+            title: Grant Statements Key
+            description: Grant Statement Object
+            minProperties: 1
+            properties:
+              database:
+                type: string
+                title: Database
+                description: Name of the database to grant permissions
+                pattern: "^[a-zA-Z0-9_-]+$"
+              statements:
+                type: array
+                title: Statements
+                description: List of grant statements to be executed
+                items:
+                  type: string
+                minItems: 1
+        connection_details:
+          title: Connection Details
+          description: Connection details for the postgres master user
+          type: object
+          properties:
+            default_database:
+              title: Default Database
+              description: Default database to connect to
+              type: string
+              default: postgres
+            sslmode:
+              title: SSL Mode
+              description: SSL mode to connect to the database
+              type: string
+              default: disable
+      required:
+        - grant_statements
+sample:
+  kind: postgres_user
+  flavor: default
+  version: "0.3"
+  metadata: {}
+  spec:
+    postgres_user:
+      role_name: test-role
+      role:
+        connection_limit: 100
+        privileges:
+          bypass_rls: false
+          create_db: false
+          create_role: false
+          inherit: false
+          login: false
+          replication: false
+          superuser: false
+      user_password: password
+      grant_statements:
+        grant_statement_1:
+          database: test_db
+          statements:
+            - 'GRANT CONNECT ON DATABASE postgres TO "test-role";'
+            - 'GRANT USAGE ON SCHEMA public TO "test-role";'
+            - 'GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO "test-role";'
+            - 'ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO "test-role";'
+            - 'GRANT USAGE ON ALL SEQUENCES IN SCHEMA public TO "test-role";'
+            - 'GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO "test-role";'
+            - 'ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT USAGE ON SEQUENCES TO "test-role";'
+        grant_statement_2:
+          database: test_db_2
+          statements:
+            - 'GRANT CONNECT ON DATABASE postgres TO "test-role";'
+            - 'GRANT USAGE ON SCHEMA public TO "test-role";'
+            - 'GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO "test-role";'
+            - 'ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO "test-role";'
+            - 'GRANT USAGE ON ALL SEQUENCES IN SCHEMA public TO "test-role";'
+            - 'GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO "test-role";'
+            - 'ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT USAGE ON SEQUENCES TO "test-role";'
+      connection_details:
+        default_database: postgres
+        sslmode: disable
+  disabled: true

--- a/modules/postgres_user/default/0.3/locals.tf
+++ b/modules/postgres_user/default/0.3/locals.tf
@@ -1,0 +1,18 @@
+locals {
+  username               = var.inputs.postgres_details.interfaces.writer.username
+  password               = var.inputs.postgres_details.interfaces.writer.password
+  host                   = var.inputs.postgres_details.interfaces.writer.host
+  port                   = var.inputs.postgres_details.interfaces.writer.port
+  spec                   = lookup(var.instance, "spec", {})
+  namespace              = lookup(lookup(var.instance, "metadata", {}), "namespace", var.environment.namespace)
+  postgres_user          = lookup(local.spec, "postgres_user", {})
+  postgres_user_password = lookup(local.postgres_user, "user_password", "") == "" ? module.user_password[0].result : lookup(local.postgres_user, "user_password", "")
+  role                   = lookup(local.postgres_user, "role", {})
+  connection_limit       = lookup(local.role, "connection_limit", 100)
+  privileges             = lookup(local.role, "privileges", {})
+  grant_statements       = lookup(local.postgres_user, "grant_statements", {})
+  role_name              = lookup(local.postgres_user, "role_name", "") == "" ? module.unique_name[0].name : lookup(local.postgres_user, "role_name", "")
+  connection_details     = lookup(local.spec, "connection_details", {})
+  sslmode                = lookup(local.connection_details, "sslmode", "disable")
+  default_database       = lookup(local.connection_details, "default_database", "postgres")
+}

--- a/modules/postgres_user/default/0.3/main.tf
+++ b/modules/postgres_user/default/0.3/main.tf
@@ -1,0 +1,113 @@
+module "unique_name" {
+  count           = lookup(local.postgres_user, "role_name", "") == "" ? 1 : 0
+  source          = "github.com/Facets-cloud/facets-utility-modules//name"
+  environment     = var.environment
+  limit           = 32
+  resource_name   = var.instance_name
+  resource_type   = "pg_user"
+  is_k8s          = true
+  globally_unique = false
+}
+
+module "user_password" {
+  count  = lookup(local.postgres_user, "user_password", "") == "" ? 1 : 0
+  source = "github.com/Facets-cloud/facets-utility-modules//password"
+  length = 32
+}
+
+resource "kubernetes_secret" "db_conn_details" {
+  metadata {
+    name      = local.role_name
+    namespace = local.namespace
+  }
+
+  data = {
+    endpoint      = local.host
+    username      = local.username
+    password      = local.password
+    port          = local.port
+    user_password = local.postgres_user_password
+    sslmode       = local.sslmode
+    database      = local.default_database
+  }
+}
+
+module "postgres-user" {
+  depends_on = [
+    kubernetes_secret.db_conn_details
+  ]
+  source    = "github.com/Facets-cloud/facets-utility-modules//any-k8s-resource"
+  name      = local.role_name
+  namespace = local.namespace
+  advanced_config = {
+    wait = true
+  }
+  data = {
+    apiVersion = "postgresql.facets.cloud/v1alpha1"
+    kind       = "Role"
+    metadata = {
+      name      = local.role_name
+      namespace = local.namespace
+      annotations = {
+        "app.kubernetes.io/managed-by" = "database-operator"
+      }
+    }
+    spec = {
+      connectSecretRef = {
+        name      = kubernetes_secret.db_conn_details.metadata[0].name
+        namespace = kubernetes_secret.db_conn_details.metadata[0].namespace
+      }
+      passwordSecretRef = {
+        name      = kubernetes_secret.db_conn_details.metadata[0].name
+        namespace = kubernetes_secret.db_conn_details.metadata[0].namespace
+        key       = "user_password"
+      },
+      connectionLimit = local.connection_limit
+      privileges = {
+        login       = true
+        bypassRls   = lookup(local.privileges, "bypass_rls", false)
+        createDb    = lookup(local.privileges, "create_db", false)
+        createRole  = lookup(local.privileges, "create_role", false)
+        inherit     = lookup(local.privileges, "inherit", false)
+        replication = lookup(local.privileges, "replication", false)
+        superUser   = lookup(local.privileges, "superUser", false)
+      }
+    }
+  }
+}
+
+
+module "postgres-grantstatement" {
+  for_each = local.grant_statements
+
+  depends_on = [
+    kubernetes_secret.db_conn_details,
+    module.postgres-user
+  ]
+
+  source    = "github.com/Facets-cloud/facets-utility-modules//any-k8s-resource"
+  name      = "${local.role_name}-${each.value.database}"
+  namespace = local.namespace
+  advanced_config = {
+    wait = true
+  }
+  data = {
+    apiVersion = "postgresql.facets.cloud/v1alpha1"
+    kind       = "GrantStatement"
+    metadata = {
+      name      = "${local.role_name}-${each.value.database}"
+      namespace = local.namespace
+      annotations = {
+        "app.kubernetes.io/managed-by" = "database-operator"
+      }
+    }
+    spec = {
+      roleRef = {
+        name      = local.role_name
+        namespace = local.namespace
+      }
+      statements = each.value.statements
+      database   = each.value.database
+    }
+  }
+}

--- a/modules/postgres_user/default/0.3/outputs.tf
+++ b/modules/postgres_user/default/0.3/outputs.tf
@@ -1,0 +1,16 @@
+locals {
+  output_attributes = {
+    username = local.role_name
+    password = local.postgres_user_password
+    secrets  = ["password"]
+  }
+  output_interfaces = {}
+}
+
+output "username" {
+  value = local.role_name
+}
+
+output "password" {
+  value = local.postgres_user_password
+}

--- a/modules/postgres_user/default/0.3/variables.tf
+++ b/modules/postgres_user/default/0.3/variables.tf
@@ -1,0 +1,41 @@
+variable "cluster" {
+  type = any
+  default = {
+  }
+}
+
+variable "baseinfra" {
+  type = any
+  default = {
+    k8s_details = {
+      registry_secret_objects = []
+    }
+  }
+}
+
+variable "cc_metadata" {
+  type = any
+  default = {
+    tenant_base_domain : "tenant.facets.cloud"
+  }
+}
+
+variable "instance" {
+  type = any
+}
+
+variable "instance_name" {
+  type = string
+}
+
+variable "environment" {
+  type = any
+  default = {
+    namespace = "default"
+  }
+}
+
+variable "inputs" {
+  type    = any
+  default = {}
+}


### PR DESCRIPTION
# Description

Adds 0.3 version of postgresql user module which uses new crd `GrantStatement` to grant permissions required to role.
The module creates the following resources:
- role-name (optional if not provided)
- password (optional if not provided)
- kubernetes secret (for storing db credentials like default db, master user and password, ssl mode etc)
- One CRS `Role` (using any k8s resource)
- Multiple  CRS `GrantStatement` at a database level.  (using any k8s resource)

Related PRs:
New CRD addition: https://github.com/Facets-cloud/postgresql-operator/pull/4
Helm chart update for database operator: https://github.com/Facets-cloud/helm-charts/pull/28

Sample:
```
{
  "kind": "postgres_user",
  "flavor": "default",
  "metadata": {},
  "spec": {
    "postgres_user": {
      "role_name": "test-role",
      "role": {
        "connection_limit": 100,
        "privileges": {
          "bypass_rls": false,
          "create_db": false,
          "create_role": false,
          "inherit": false,
          "login": true,
          "replication": false,
          "superuser": false
        }
      },
      "user_password": "password",
      "grant_statements": {
        "grant_statements_1": {
          "database": "catalog",
          "statements": [
            "GRANT CONNECT ON DATABASE catalog TO \"test-role\";",
            "GRANT USAGE ON SCHEMA public TO \"test-role\";",
            "GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO \"test-role\";",
            "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO \"test-role\";",
            "GRANT USAGE ON ALL SEQUENCES IN SCHEMA public TO \"test-role\";",
            "GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO \"test-role\";",
            "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT USAGE ON SEQUENCES TO \"test-role\";"
          ]
        },
        "grant_statements_2": {
          "database": "role-manager",
          "statements": [
            "GRANT CONNECT ON DATABASE \"role-manager\" TO \"test-role\";",
            "GRANT USAGE ON SCHEMA public TO \"test-role\";",
            "GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO \"test-role\";",
            "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO \"test-role\";",
            "GRANT USAGE ON ALL SEQUENCES IN SCHEMA public TO \"test-role\";",
            "GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO \"test-role\";",
            "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT USAGE ON SEQUENCES TO \"test-role\";"
          ]
        }
      },
      "connection_details": {
        "default_database": "postgres",
        "sslmode": "disable"
      }
    }
  },
  "version": "0.3-pg-grant-stmt",
  "disabled": true,
  "inputs": {
    "kubernetes_details": {
      "resource_name": "default",
      "resource_type": "kubernetes_cluster"
    },
    "database_operator_details": {
      "resource_name": "db-op",
      "resource_type": "database_operator"
    },
    "postgres_details": {
      "resource_name": "rds-postgres-test",
      "resource_type": "postgres"
    }
  }
}
```

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Related issues
<!-- If this PR is related to an existing issue or feature request, please reference clickup task url here. -->

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist
<!-- Please delete options that are not relevant. -->

- [x] I have created feat/bugfix branch out of `develop` branch
- [x] Code passes linting/formatting checks
- [x] Changes to resources have been tested in our dev environments
- [ ] I have made corresponding changes to the documentation

## Testing

<!-- Detail how the changes have been tested, including any automated or manual tests performed. Include the results of the testing (Screenshots, links to releases, etc.), including any issues or bugs encountered and how they were resolved -->

Installing new CRDs using helm chart and image overrides
- release link: https://facetsdemo.console.facets.cloud/capc/stack/infra-dev/releases/cluster/64b0fe30f8ae8b0007f5f010/dialog/release-details/67bcdba0fb4f6c0007d6b81b
<img width="1440" alt="Screenshot 2025-02-25 at 2 36 24 AM" src="https://github.com/user-attachments/assets/b15d1edc-f22d-4165-a79a-123338869077" />

Creating new role and granting permissions
- release link: https://facetsdemo.console.facets.cloud/capc/stack/infra-dev/releases/cluster/64b0fe30f8ae8b0007f5f010/dialog/release-details/67bcdba0fb4f6c0007d6b81b
<img width="1440" alt="Screenshot 2025-02-25 at 2 37 26 AM" src="https://github.com/user-attachments/assets/60b479c8-ba04-4233-b22e-fa55a1ddad95" />
<img width="1440" alt="Screenshot 2025-02-25 at 2 37 36 AM" src="https://github.com/user-attachments/assets/dd2abf94-742a-46d9-a303-03c8c3e52e67" />
<img width="1439" alt="Screenshot 2025-02-25 at 2 37 43 AM" src="https://github.com/user-attachments/assets/9055f899-daf5-4ff8-a687-7df6ac695ab6" />
<img width="1440" alt="Screenshot 2025-02-25 at 2 24 18 AM" src="https://github.com/user-attachments/assets/ae2199ed-9b6b-4a8e-8830-7741c814f569" />

Deleting role and permissions
- release link: https://facetsdemo.console.facets.cloud/capc/stack/infra-dev/releases/cluster/64b0fe30f8ae8b0007f5f010/dialog/release-details/67bcdc99fb4f6c0007d6bdf3
<img width="1440" alt="Screenshot 2025-02-25 at 2 27 35 AM" src="https://github.com/user-attachments/assets/959d4d77-ecab-4820-8cd5-cacecee1c93b" />

Updating the grant statements
- release link: https://facetsdemo.console.facets.cloud/capc/stack/infra-dev/releases/cluster/64b0fe30f8ae8b0007f5f010/dialog/release-details/67bd603afb4f6c0007fd6f72
<img width="1439" alt="Screenshot 2025-02-25 at 11 48 01 AM" src="https://github.com/user-attachments/assets/245b89a2-d486-40f1-8dcc-49394fe56b0f" />



