### PR TITLE
add support for workload identity

### DIFF
--- a/index.json
+++ b/index.json
@@ -593,6 +593,10 @@
   },
   {
     "gitUrl": "https://github.com/Facets-cloud/facets-modules",
+    "relativePath": "./modules/google_workload_identity/default/0.1/"
+  },
+  {
+    "gitUrl": "https://github.com/Facets-cloud/facets-modules",
     "relativePath": "./modules/postgres/external/0.1/"
   }
 ]

--- a/intents.index.json
+++ b/intents.index.json
@@ -338,5 +338,9 @@
   {
     "gitUrl": "https://github.com/Facets-cloud/facets-modules",
     "relativePath": "./intents/image_pull_secret_injector/"
+  },
+  {
+    "gitUrl": "https://github.com/Facets-cloud/facets-modules",
+    "relativePath": "./intents/google_workload_identity/"
   }
 ]

--- a/intents/google_workload_identity/facets.yaml
+++ b/intents/google_workload_identity/facets.yaml
@@ -1,0 +1,7 @@
+name: google_workload_identity
+type: IAM
+displayName: Google Workload Identity
+description: Workload Identity is the recommended way to access GCP services from Kubernetes. [Read more] (https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity).
+outputs:
+  default:
+    type: "@outputs/google_workload_identity"

--- a/modules/google_workload_identity/default/1.0/README.md
+++ b/modules/google_workload_identity/default/1.0/README.md
@@ -84,11 +84,10 @@ spec:
 
 | Name                             | Description                           |
 | -------------------------------- | ------------------------------------- |
-| gcp\_service\_account            | GCP service account.                  |
-| gcp\_service\_account\_email     | Email address of GCP service account. |
-| gcp\_service\_account\_fqn       | FQN of GCP service account.           |
-| gcp\_service\_account\_name      | Name of GCP service account.          |
-| k8s\_service\_account\_name      | Name of k8s service account.          |
-| k8s\_service\_account\_namespace | Namespace of k8s service account.     |
+| gcp\_sa\_email     | Email address of GCP service account. |
+| gcp\_sa\_fqn       | FQN of GCP service account.           |
+| gcp\_sa\_name      | Name of GCP service account.          |
+| k8s\_sa\_name      | Name of k8s service account.          |
+| k8s\_sa\_namespace | Namespace of k8s service account.     |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/google_workload_identity/default/1.0/README.md
+++ b/modules/google_workload_identity/default/1.0/README.md
@@ -1,0 +1,94 @@
+# terraform-google-workload-identity
+
+[`Workload Identity`](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) is the recommended way to access GCP services from Kubernetes.
+
+This resource creates:
+
+* IAM Service Account binding to `roles/iam.workloadIdentityUser`
+* Optionally, a Google Service Account
+* Optionally, a Kubernetes Service Account
+
+## Usage
+
+This resource can create service accounts for you,
+or you can use existing accounts; this applies for both the Google and
+Kubernetes accounts.
+
+### Creating a Workload Identity
+
+```json
+{
+  "kind": "google_workload_identity",
+  "flavor": "default",
+  "version": "1.0",
+  "disabled": true,
+  "spec": {
+    "name": "petclinic",
+    "gcp_sa_name": "petclinic",
+    "use_existing_gcp_sa": false,
+    "gcp_sa_description": "GCP Service Account for petclinic application",
+    "gcp_sa_create_ignore_already_exists": false,
+    "k8s_sa_name": "petclinic-sa",
+    "use_existing_k8s_sa": false,
+    "namespace": "default",
+    "roles": {
+      "storage-admin": {
+        "role": "roles/storage.admin"
+      },
+      "compute-admin": {
+        "role": "roles/compute.admin"
+      }
+    }
+  }
+}
+```
+
+This will create:
+
+* Google Service Account named: `gcp_sa_name@gcp-project-name.iam.gserviceaccount.com`
+* Kubernetes Service Account named: `k8s_sa_name` in the `default` namespace
+* IAM Binding (`roles/iam.workloadIdentityUser`) between the service accounts
+
+Usage from a Kubernetes deployment:
+
+```yaml
+metadata:
+  namespace: default
+  # ...
+spec:
+  # ...
+  template:
+    spec:
+      serviceAccountName: k8s_sa_name
+```
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Inputs
+
+| Name                                     | Description                                                                                                                                                    | Type                | Default     | Required |
+| ---------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------- | ----------- | :------: |
+| annotate\_k8s\_sa                        | Annotate the kubernetes service account with 'iam.gke.io/gcp-service-account' annotation. Valid in cases when an existing SA is used.                          | `bool`              | `true`      |    no    |
+| automount\_service\_account\_token       | Enable automatic mounting of the service account token                                                                                                         | `bool`              | `false`     |    no    |
+| gcp\_sa\_create\_ignore\_already\_exists | If set to true, skip service account creation if a service account with the same email already exists.                                                         | `bool`              | `null`      |    no    |
+| gcp\_sa\_description                     | The Service Google service account desciption; if null, will be left out                                                                                       | `string`            | `null`      |    no    |
+| gcp\_sa\_name                            | Name for the Google service account; overrides `var.name`.                                                                                                     | `string`            | `null`      |    no    |
+| k8s\_sa\_name                            | Name for the Kubernetes service account; overrides `var.name`. `cluster_name` and `location` must be set when this input is specified.                         | `string`            | `null`      |    no    |
+| name                                     | Name for both service accounts. The GCP SA will be truncated to the first 30 chars if necessary.                                                               | `string`            | n/a         |   yes    |
+| namespace                                | Namespace for the Kubernetes service account                                                                                                                   | `string`            | `"default"` |    no    |
+| project\_id                              | GCP project ID                                                                                                                                                 | `string`            | n/a         |   yes    |
+| roles                                    | A map of key to role object to be added to the created service account                                                                                                     | `map(string)`      | `null`        |    yes    |
+| use\_existing\_gcp\_sa                   | Use an existing Google service account instead of creating one                                                                                                 | `bool`              | `false`     |    no    |
+| use\_existing\_k8s\_sa                   | Use an existing kubernetes service account instead of creating one                                                                                             | `bool`              | `false`     |    no    |
+
+## Outputs
+
+| Name                             | Description                           |
+| -------------------------------- | ------------------------------------- |
+| gcp\_service\_account            | GCP service account.                  |
+| gcp\_service\_account\_email     | Email address of GCP service account. |
+| gcp\_service\_account\_fqn       | FQN of GCP service account.           |
+| gcp\_service\_account\_name      | Name of GCP service account.          |
+| k8s\_service\_account\_name      | Name of k8s service account.          |
+| k8s\_service\_account\_namespace | Namespace of k8s service account.     |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/google_workload_identity/default/1.0/facets.yaml
+++ b/modules/google_workload_identity/default/1.0/facets.yaml
@@ -1,0 +1,124 @@
+intent: google_workload_identity
+flavor: default
+version: "1.0"
+clouds: [gcp]
+description: Workload Identity is the recommended way to access GCP services from Kubernetes. [Read more] (https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity).
+inputs:
+  kubernetes_details:
+    optional: false
+    type: "@output/kubernetes"
+    displayName: Kubernetes Cluster
+    description: Details of Kubernetes where the kubernetes service account will be created.
+    default:
+      resource_type: kubernetes_cluster
+      resource_name: default
+spec:
+  title: Google Workload Identity
+  description: Workload Identity is the recommended way to access GCP services from Kubernetes. [Read more] (https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity).
+  type: object
+  properties:
+    name:
+      type: string
+      title: Name
+      description: Name for both service accounts (GCP and Kubernetes). The GCP SA will be truncated to the first 30 chars if necessary.
+      pattern: "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
+      minLength: 6
+      maxLength: 253
+      x-ui-error-message: "Workload identity pool ids must be <= 30 chars matching regex ^[a-z](?:[-a-z0-9]{4,28}[a-z0-9])$"
+      x-ui-placeholder: "Enter the name of the workload identity pool"
+    gcp_sa_name:
+      type: string
+      title: GCP Service Account Name
+      description: The name of the GCP Service Account. Overrides the common name given above.
+      pattern: "^[a-z](?:[-a-z0-9]{4,28}[a-z0-9])$"
+      minLength: 6
+      maxLength: 30
+      x-ui-error-message: "GCP service account ids must be <= 30 chars matching regex ^[a-z](?:[-a-z0-9]{4,28}[a-z0-9])$"
+      x-ui-placeholder: "Enter the name of the GCP service account"
+    use_existing_gcp_sa:
+      type: boolean
+      title: Use Existing GCP Service Account
+      description: If true, the GCP service account will not be created. Instead, the existing GCP service account will be used.
+      default: false
+    gcp_sa_description:
+      type: string
+      title: GCP Service Account Description
+      description: The description of the GCP Service Account.
+      minLength: 0
+      maxLength: 1024
+      x-ui-error-message: "GCP service account description must be <= 1024 chars"
+      x-ui-placeholder: "Enter the description of the GCP service account"
+      x-ui-visible-if:
+        field: spec.use_existing_gcp_sa
+        values: [false]
+    k8s_sa_name:
+      type: string
+      title: Kubernetes Service Account Name
+      description: The name of the Kubernetes Service Account. Overrides the common name given above.
+      pattern: "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
+      minLength: 6
+      maxLength: 253
+      x-ui-error-message: "Kubernetes service account must match regex ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$ and must be <= 253 chars"
+      x-ui-placeholder: "Enter the name of the Kubernetes service account."
+    use_existing_k8s_sa:
+      type: boolean
+      title: Use Existing Kubernetes Service Account
+      description: If true, the Kubernetes service account will not be created. Instead, the existing Kubernetes service account will be used.
+      default: false
+    namespace:
+      type: string
+      title: Namespace
+      description: The namespace in which the Kubernetes Service Account will be created. If not provided, the default namespace of the environment will be used.
+      pattern: "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
+      minLength: 1
+      maxLength: 63
+      x-ui-error-message: "Namespace must match regex ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$ and must be <= 63 chars"
+      x-ui-placeholder: "Enter the name of the namespace. Eg. default"
+    annotate_k8s_sa:
+      type: boolean
+      title: Annotate Kubernetes Service Account
+      description: If true, the Kubernetes Service Account will be annotated with the GCP Service Account email.
+      default: true
+      x-ui-visible-if:
+        field: spec.use_existing_k8s_sa
+        values: [true]
+    roles:
+      title: Roles
+      description: Map of keys to roles that should be assigned to the GCP Service Account. The keys can be any alpha-numeric strings, but the values must be valid GCP roles defined in the GCP IAM roles.
+      type: object
+      patternProperties:
+        keyPattern: "^[a-zA-Z0-9_]+$"
+        title: Role Key
+        type: string
+        description: Role Object which contains the role to be assigned to the service account.
+        properties:
+          role:
+            type: string
+            title: Role
+            description: The GCP role to be assigned to the service account.
+        required:
+          - role
+        minLength: 1
+  required:
+    - name
+    - use_existing_gcp_sa
+    - use_existing_k8s_sa
+    - roles
+sample:
+  kind: google_workload_identity
+  flavor: default
+  version: "1.0"
+  disabled: true
+  spec:
+    name: petclinic
+    gcp_sa_name: petclinic
+    use_existing_gcp_sa: false
+    gcp_sa_description: GCP Service Account for petclinic application
+    k8s_sa_name: petclinic-sa
+    use_existing_k8s_sa: false
+    namespace: default
+    roles:
+      storage-admin:
+        role: roles/storage.admin
+      compute-admin:
+        role: roles/compute.admin

--- a/modules/google_workload_identity/default/1.0/facets.yaml
+++ b/modules/google_workload_identity/default/1.0/facets.yaml
@@ -111,10 +111,8 @@ sample:
   disabled: true
   spec:
     name: petclinic
-    gcp_sa_name: petclinic
     use_existing_gcp_sa: false
     gcp_sa_description: GCP Service Account for petclinic application
-    k8s_sa_name: petclinic-sa
     use_existing_k8s_sa: false
     namespace: default
     roles:

--- a/modules/google_workload_identity/default/1.0/facets.yaml
+++ b/modules/google_workload_identity/default/1.0/facets.yaml
@@ -20,7 +20,7 @@ spec:
     name:
       type: string
       title: Name
-      description: Name for both service accounts (GCP and Kubernetes). The GCP SA will be truncated to the first 30 chars if necessary.
+      description: Name for both service accounts (GCP and Kubernetes). The GCP SA will be truncated to the first 30 chars if necessary. Use GCP SA Name to override the name of the GCP SA and Kubernetes SA Name to override the name of the Kubernetes SA.
       pattern: "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
       minLength: 6
       maxLength: 253
@@ -35,11 +35,6 @@ spec:
       maxLength: 30
       x-ui-error-message: "GCP service account ids must be <= 30 chars matching regex ^[a-z](?:[-a-z0-9]{4,28}[a-z0-9])$"
       x-ui-placeholder: "Enter the name of the GCP service account"
-    use_existing_gcp_sa:
-      type: boolean
-      title: Use Existing GCP Service Account
-      description: If true, the GCP service account will not be created. Instead, the existing GCP service account will be used.
-      default: false
     gcp_sa_description:
       type: string
       title: GCP Service Account Description
@@ -51,6 +46,11 @@ spec:
       x-ui-visible-if:
         field: spec.use_existing_gcp_sa
         values: [false]
+    use_existing_gcp_sa:
+      type: boolean
+      title: Use Existing GCP Service Account
+      description: If true, the GCP service account will not be created. Instead, the existing GCP service account will be used.
+      default: false
     k8s_sa_name:
       type: string
       title: Kubernetes Service Account Name
@@ -60,11 +60,6 @@ spec:
       maxLength: 253
       x-ui-error-message: "Kubernetes service account must match regex ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$ and must be <= 253 chars"
       x-ui-placeholder: "Enter the name of the Kubernetes service account."
-    use_existing_k8s_sa:
-      type: boolean
-      title: Use Existing Kubernetes Service Account
-      description: If true, the Kubernetes service account will not be created. Instead, the existing Kubernetes service account will be used.
-      default: false
     namespace:
       type: string
       title: Namespace
@@ -74,11 +69,16 @@ spec:
       maxLength: 63
       x-ui-error-message: "Namespace must match regex ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$ and must be <= 63 chars"
       x-ui-placeholder: "Enter the name of the namespace. Eg. default"
+    use_existing_k8s_sa:
+      type: boolean
+      title: Use Existing Kubernetes Service Account
+      description: If true, the Kubernetes service account will not be created. Instead, the existing Kubernetes service account will be used.
+      default: false
     annotate_k8s_sa:
       type: boolean
       title: Annotate Kubernetes Service Account
       description: If true, the Kubernetes Service Account will be annotated with the GCP Service Account email.
-      default: true
+      default: false
       x-ui-visible-if:
         field: spec.use_existing_k8s_sa
         values: [true]

--- a/modules/google_workload_identity/default/1.0/locals.tf
+++ b/modules/google_workload_identity/default/1.0/locals.tf
@@ -1,0 +1,25 @@
+locals {
+  # GCP service account ids must be <= 30 chars matching regex ^[a-z](?:[-a-z0-9]{4,28}[a-z0-9])$
+  # KSAs do not have this naming restriction.
+  spec                            = var.instance.spec
+  name                            = lookup(var.instance.spec, "name", null)
+  gcp_sa_name                     = lookup(var.instance.spec, "gcp_sa_name", null)
+  k8s_sa_name                     = lookup(var.instance.spec, "k8s_sa_name", null)
+  use_existing_gcp_sa             = lookup(var.instance.spec, "use_existing_gcp_sa", false)
+  use_existing_k8s_sa             = lookup(var.instance.spec, "use_existing_k8s_sa", false)
+  namespace                       = lookup(var.instance.spec, "namespace", var.environment.namespace)
+  project_id                      = var.inputs.kubernetes_details.attributes.legacy_outputs.gcp_cloud.project_id
+  gcp_sa_description              = lookup(var.instance.spec, "gcp_sa_description", "GCP Service Account bound to K8S Service Account ${local.project_id} ${local.k8s_given_name}")
+  automount_service_account_token = lookup(var.instance.spec, "automount_service_account_token", false)
+  annotate_k8s_sa                 = lookup(var.instance.spec, "annotate_k8s_sa", true)
+  roles_map                       = lookup(var.instance.spec, "roles", {})
+  roles                           = toset([for key, value in local.roles_map : lookup(value, "role", null)])
+
+  gcp_given_name          = local.gcp_sa_name != null ? local.gcp_sa_name : trimsuffix(substr(local.name, 0, 30), "-")
+  gcp_sa_email            = local.use_existing_gcp_sa ? data.google_service_account.cluster_service_account[0].email : google_service_account.cluster_service_account[0].email
+  gcp_sa_fqn              = "serviceAccount:${local.gcp_sa_email}"
+  k8s_given_name          = local.k8s_sa_name != null ? local.k8s_sa_name : local.name
+  output_k8s_name         = local.use_existing_k8s_sa ? local.k8s_given_name : kubernetes_service_account.main[0].metadata[0].name
+  output_k8s_namespace    = local.use_existing_k8s_sa ? local.namespace : kubernetes_service_account.main[0].metadata[0].namespace
+  k8s_sa_gcp_derived_name = "serviceAccount:${local.project_id}.svc.id.goog[${local.namespace}/${local.output_k8s_name}]"
+}

--- a/modules/google_workload_identity/default/1.0/main.tf
+++ b/modules/google_workload_identity/default/1.0/main.tf
@@ -1,3 +1,14 @@
+module "unique_name" {
+  count           = local.gcp_sa_name == "" || local.gcp_sa_name == null ? 1 : 0
+  source          = "github.com/Facets-cloud/facets-utility-modules//name"
+  environment     = var.environment
+  limit           = 30
+  resource_name   = local.name
+  resource_type   = "google_workload_identity"
+  is_k8s          = false
+  globally_unique = true
+}
+
 data "google_service_account" "cluster_service_account" {
   count = local.use_existing_gcp_sa ? 1 : 0
 
@@ -50,7 +61,7 @@ resource "null_resource" "annotate-sa" {
   }
 
   provisioner "local-exec" {
-    when = "create"
+    when = create
     environment = {
       SERVER = sensitive(var.inputs.kubernetes_details.attributes.legacy_outputs.k8s_details.auth.host)
       CA     = sensitive(base64encode(var.inputs.kubernetes_details.attributes.legacy_outputs.k8s_details.auth.cluster_ca_certificate))

--- a/modules/google_workload_identity/default/1.0/main.tf
+++ b/modules/google_workload_identity/default/1.0/main.tf
@@ -1,0 +1,78 @@
+data "google_service_account" "cluster_service_account" {
+  count = local.use_existing_gcp_sa ? 1 : 0
+
+  account_id = local.gcp_given_name
+  project    = local.project_id
+}
+
+resource "google_service_account" "cluster_service_account" {
+  count = local.use_existing_gcp_sa ? 0 : 1
+
+  account_id   = local.gcp_given_name
+  display_name = substr("GCP SA bound to K8S SA ${local.project_id} ${local.k8s_given_name}", 0, 100)
+  description  = local.gcp_sa_description
+  project      = local.project_id
+}
+
+resource "kubernetes_service_account" "main" {
+  count = local.use_existing_k8s_sa ? 0 : 1
+
+  automount_service_account_token = local.automount_service_account_token
+
+  dynamic "image_pull_secret" {
+    for_each = var.inputs.kubernetes_details.attributes.legacy_outputs.registry_secret_objects
+    content {
+      name = image_pull_secret.value["name"]
+    }
+  }
+
+  metadata {
+    name      = local.k8s_given_name
+    namespace = local.namespace
+    annotations = {
+      "iam.gke.io/gcp-service-account" = local.gcp_sa_email
+    }
+    labels = {
+      resource_type = "workload_identity"
+      resource_name = var.instance_name
+    }
+  }
+}
+
+resource "null_resource" "annotate-sa" {
+  count = local.use_existing_k8s_sa && local.annotate_k8s_sa ? 1 : 0
+
+  triggers = {
+    auth          = base64encode(jsonencode(var.inputs.kubernetes_details.attributes.legacy_outputs.k8s_details.auth))
+    ksa_namespace = local.output_k8s_namespace
+    ksa_name      = local.k8s_given_name
+    gcp_sa_email  = local.gcp_sa_email
+  }
+
+  provisioner "local-exec" {
+    when = "create"
+    environment = {
+      SERVER = sensitive(var.inputs.kubernetes_details.attributes.legacy_outputs.k8s_details.auth.host)
+      CA     = sensitive(base64encode(var.inputs.kubernetes_details.attributes.legacy_outputs.k8s_details.auth.cluster_ca_certificate))
+      TOKEN  = sensitive(var.inputs.kubernetes_details.attributes.legacy_outputs.k8s_details.auth.token)
+    }
+    command = <<EOT
+    /bin/bash ../tfmain/scripts/run_with_kubeconfig.sh kubectl annotate --overwrite sa -n ${self.triggers.ksa_namespace} ${self.triggers.ksa_name} iam.gke.io/gcp-service-account=${self.triggers.gcp_sa_email}
+    EOT
+  }
+}
+
+resource "google_service_account_iam_member" "main" {
+  service_account_id = local.use_existing_gcp_sa ? data.google_service_account.cluster_service_account[0].name : google_service_account.cluster_service_account[0].name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = local.k8s_sa_gcp_derived_name
+}
+
+resource "google_project_iam_member" "workload_identity_sa_bindings" {
+  for_each = toset(local.roles)
+
+  project = local.project_id
+  role    = each.value
+  member  = local.gcp_sa_fqn
+}
+

--- a/modules/google_workload_identity/default/1.0/output.tf
+++ b/modules/google_workload_identity/default/1.0/output.tf
@@ -6,6 +6,6 @@ locals {
     "gcp_sa_email"     = local.gcp_sa_email
     "gcp_sa_fqn"       = local.gcp_sa_fqn
     "gcp_sa_name"      = local.k8s_sa_gcp_derived_name
-    "gcp_sa_id"        = local.gcp_given_name
+    "gcp_sa_id"        = local.gcp_sa_id
   }
 }

--- a/modules/google_workload_identity/default/1.0/output.tf
+++ b/modules/google_workload_identity/default/1.0/output.tf
@@ -9,33 +9,3 @@ locals {
     "gcp_service_account"           = local.use_existing_gcp_sa ? data.google_service_account.cluster_service_account[0] : google_service_account.cluster_service_account[0]
   }
 }
-
-output "k8s_service_account_name" {
-  description = "Name of k8s service account."
-  value       = local.output_k8s_name
-}
-
-output "k8s_service_account_namespace" {
-  description = "Namespace of k8s service account."
-  value       = local.output_k8s_namespace
-}
-
-output "gcp_service_account_email" {
-  description = "Email address of GCP service account."
-  value       = local.gcp_sa_email
-}
-
-output "gcp_service_account_fqn" {
-  description = "FQN of GCP service account."
-  value       = local.gcp_sa_fqn
-}
-
-output "gcp_service_account_name" {
-  description = "Name of GCP service account."
-  value       = local.k8s_sa_gcp_derived_name
-}
-
-output "gcp_service_account" {
-  description = "GCP service account."
-  value       = local.use_existing_gcp_sa ? data.google_service_account.cluster_service_account[0] : google_service_account.cluster_service_account[0]
-}

--- a/modules/google_workload_identity/default/1.0/output.tf
+++ b/modules/google_workload_identity/default/1.0/output.tf
@@ -1,0 +1,41 @@
+locals {
+  output_interfaces = {}
+  output_attributes = {
+    "k8s_service_account_name"      = local.output_k8s_name
+    "k8s_service_account_namespace" = local.output_k8s_namespace
+    "gcp_service_account_email"     = local.gcp_sa_email
+    "gcp_service_account_fqn"       = local.gcp_sa_fqn
+    "gcp_service_account_name"      = local.k8s_sa_gcp_derived_name
+    "gcp_service_account"           = local.use_existing_gcp_sa ? data.google_service_account.cluster_service_account[0] : google_service_account.cluster_service_account[0]
+  }
+}
+
+output "k8s_service_account_name" {
+  description = "Name of k8s service account."
+  value       = local.output_k8s_name
+}
+
+output "k8s_service_account_namespace" {
+  description = "Namespace of k8s service account."
+  value       = local.output_k8s_namespace
+}
+
+output "gcp_service_account_email" {
+  description = "Email address of GCP service account."
+  value       = local.gcp_sa_email
+}
+
+output "gcp_service_account_fqn" {
+  description = "FQN of GCP service account."
+  value       = local.gcp_sa_fqn
+}
+
+output "gcp_service_account_name" {
+  description = "Name of GCP service account."
+  value       = local.k8s_sa_gcp_derived_name
+}
+
+output "gcp_service_account" {
+  description = "GCP service account."
+  value       = local.use_existing_gcp_sa ? data.google_service_account.cluster_service_account[0] : google_service_account.cluster_service_account[0]
+}

--- a/modules/google_workload_identity/default/1.0/output.tf
+++ b/modules/google_workload_identity/default/1.0/output.tf
@@ -1,11 +1,11 @@
 locals {
   output_interfaces = {}
   output_attributes = {
-    "k8s_service_account_name"      = local.output_k8s_name
-    "k8s_service_account_namespace" = local.output_k8s_namespace
-    "gcp_service_account_email"     = local.gcp_sa_email
-    "gcp_service_account_fqn"       = local.gcp_sa_fqn
-    "gcp_service_account_name"      = local.k8s_sa_gcp_derived_name
-    "gcp_service_account"           = local.use_existing_gcp_sa ? data.google_service_account.cluster_service_account[0] : google_service_account.cluster_service_account[0]
+    "k8s_sa_name"      = local.output_k8s_name
+    "k8s_sa_namespace" = local.output_k8s_namespace
+    "gcp_sa_email"     = local.gcp_sa_email
+    "gcp_sa_fqn"       = local.gcp_sa_fqn
+    "gcp_sa_name"      = local.k8s_sa_gcp_derived_name
+    "gcp_sa_id"        = local.gcp_given_name
   }
 }

--- a/modules/google_workload_identity/default/1.0/variables.tf
+++ b/modules/google_workload_identity/default/1.0/variables.tf
@@ -1,0 +1,45 @@
+variable "instance" {
+  description = "Workload Identity is the recommended way to access GCP services from Kubernetes. [Read more] (https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity)."
+  type = object({
+    kind    = string
+    flavor  = string
+    version = string
+    spec = object({
+    })
+  })
+}
+variable "instance_name" {
+  description = "The architectural name for the resource as added in the Facets blueprint designer."
+  type        = string
+}
+variable "environment" {
+  description = "An object containing details about the environment."
+  type = object({
+    name        = string
+    unique_name = string
+    project     = string
+    namespace   = string
+  })
+}
+variable "inputs" {
+  description = "A map of inputs requested by the module developer."
+  type = object({
+    kubernetes_details = object({
+      attributes = object({
+        legacy_outputs = object({
+          k8s_details = object({
+            auth = object({
+              host                   = string
+              cluster_ca_certificate = string
+              token                  = string
+            })
+          })
+          gcp_cloud = object({
+            project_id = string
+          })
+        })
+      })
+    })
+  })
+}
+

--- a/modules/google_workload_identity/default/1.0/variables.tf
+++ b/modules/google_workload_identity/default/1.0/variables.tf
@@ -37,6 +37,7 @@ variable "inputs" {
           gcp_cloud = object({
             project_id = string
           })
+          registry_secret_objects = any
         })
       })
     })

--- a/outputs.index.json
+++ b/outputs.index.json
@@ -228,5 +228,9 @@
     "name": "kms",
     "gitUrl": "https://github.com/Facets-cloud/facets-modules",
     "relativePath": "./outputs/kms/"
+  },
+  {
+    "gitUrl": "https://github.com/Facets-cloud/facets-modules",
+    "relativePath": "./outputs/google_workload_identity/"
   }
 ]

--- a/outputs/google_workload_identity/output.facets.yaml
+++ b/outputs/google_workload_identity/output.facets.yaml
@@ -21,3 +21,6 @@ out:
       gcp_sa_fqn:
         type: string
         required: true
+      gcp_sa_id:
+        type: string
+        required: true

--- a/outputs/google_workload_identity/output.facets.yaml
+++ b/outputs/google_workload_identity/output.facets.yaml
@@ -1,0 +1,26 @@
+name: google_workload_identity
+out:
+  type: object
+  title: Google Workload Identity
+  description: Workload Identity is the recommended way to access GCP services from Kubernetes. [Read more] (https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity).
+  properties:
+    interfaces: null
+    attributes:
+      k8s_service_account_name:
+        type: string
+        required: true
+      k8s_service_account_namespace:
+        type: string
+        required: true
+      gcp_service_account_name:
+        type: string
+        required: true
+      gcp_service_account_email:
+        type: string
+        required: true
+      gcp_service_account_fqn:
+        type: string
+        required: true
+      gcp_service_account:
+        type: object
+        required: true

--- a/outputs/google_workload_identity/output.facets.yaml
+++ b/outputs/google_workload_identity/output.facets.yaml
@@ -6,21 +6,18 @@ out:
   properties:
     interfaces: null
     attributes:
-      k8s_service_account_name:
+      k8s_sa_name:
         type: string
         required: true
-      k8s_service_account_namespace:
+      k8s_sa_namespace:
         type: string
         required: true
-      gcp_service_account_name:
+      gcp_sa_name:
         type: string
         required: true
-      gcp_service_account_email:
+      gcp_sa_email:
         type: string
         required: true
-      gcp_service_account_fqn:
+      gcp_sa_fqn:
         type: string
-        required: true
-      gcp_service_account:
-        type: object
         required: true


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This pr adds support for workload identity to be created for binding privileges of google service account to k8s service account in gcp cloud.

This is required to give secret manager privileges for release pod in gcp hosted control planes. Adding this as there is no per instance module for workload identity.

Sample JSON:

```json
{
  "flavor": "default",
  "kind": "google_workload_identity",
  "inputs": {
    "kubernetes_details": {
      "resource_name": "default",
      "resource_type": "kubernetes_cluster"
    }
  },
  "disabled": false,
  "version": "1.0",
  "spec": {
    "gcp_sa_description": "facets-release-pod",
    "gcp_sa_name": "facets-release-pod",
    "k8s_sa_name": "facets-release-pod",
    "name": "facets-release-pod",
    "namespace": "default",
    "roles": {
      "secretmanager-viewer": {
        "role": "roles/secretmanager.viewer"
      },
      "secretmanager-secret-accessor": {
        "role": "roles/secretmanager.secretAccessor"
      }
    },
    "use_existing_gcp_sa": false,
    "use_existing_k8s_sa": false
  }
}
```
[More Details](https://github.com/Facets-cloud/facets-modules/blob/workload-identity/modules/google_workload_identity/default/1.0/README.md)


## Related issues
<!-- If this PR is related to an existing issue or feature request, please reference clickup task url here. -->
https://app.clickup.com/t/86cyfc9t4

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist
<!-- Please delete options that are not relevant. -->

- [ ] I have created feat/bugfix branch out of `develop` branch
- [x] Code passes linting/formatting checks
- [x] Changes to resources have been tested in our dev environments
- [ ] I have made corresponding changes to the documentation

## Testing

<!-- Detail how the changes have been tested, including any automated or manual tests performed. Include the results of the testing (Screenshots, links to releases, etc.), including any issues or bugs encountered and how they were resolved -->

### Form
<img width="1440" alt="Screenshot 2025-04-07 at 5 36 04 PM" src="https://github.com/user-attachments/assets/110a31e1-d411-4583-9257-0dcb9c4dce5e" />
<img width="1440" alt="Screenshot 2025-04-07 at 5 36 17 PM" src="https://github.com/user-attachments/assets/09e842ad-c934-4d5e-8fed-719a0d7ff959" />
<img width="1440" alt="Screenshot 2025-04-07 at 5 36 24 PM" src="https://github.com/user-attachments/assets/f0ea0648-14fd-4e58-bb20-7257891716f9" />


### Creating Resource:
- Release Link : https://root.console.facets.cloud/capc/stack/fcp/releases/cluster/67ed174138efc00007c6780f/dialog/release-details/67f3beed4bd44c0007f5cdc8
<img width="1432" alt="Screenshot 2025-04-07 at 5 34 30 PM" src="https://github.com/user-attachments/assets/456e55c1-86bb-492a-869f-18b1dabb9bab" />

<img width="1439" alt="Screenshot 2025-04-07 at 5 33 53 PM" src="https://github.com/user-attachments/assets/c114efca-9513-4fe0-bf31-01696f8c3572" />

### Destruction:
- Release Link:
https://root.console.facets.cloud/capc/stack/fcp/releases/cluster/67ed174138efc00007c6780f/dialog/release-details/67f3bd3b4bd44c0007f5cd65
<img width="1328" alt="Screenshot 2025-04-07 at 5 31 44 PM" src="https://github.com/user-attachments/assets/2ecc946c-e3da-4dba-b006-3966e7510140" />



