### PR TITLE
update the default helm chart version for database operator

### DIFF
--- a/modules/database_operator/default/0.1/main.tf
+++ b/modules/database_operator/default/0.1/main.tf
@@ -2,7 +2,7 @@ resource "helm_release" "database-operator" {
   name             = "database-operator"
   repository       = "https://facets-cloud.github.io/helm-charts"
   chart            = "database-operator"
-  version          = lookup(local.database_operator, "version", "1.0.1")
+  version          = lookup(local.database_operator, "version", "1.1.0")
   cleanup_on_fail  = lookup(local.database_operator, "cleanup_on_fail", true)
   namespace        = local.namespace
   create_namespace = lookup(local.database_operator, "create_namespace", false)


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Update the default version of database operator helm chart to `1.1.0`
Ref Link: https://github.com/Facets-cloud/helm-charts/blob/1e9b201cb4433064ffcdd8e2b941ab207acd0460/database-operator/Chart.yaml#L5

## Related issues
<!-- If this PR is related to an existing issue or feature request, please reference clickup task url here. -->

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist
<!-- Please delete options that are not relevant. -->

- [ ] I have created feat/bugfix branch out of `develop` branch
- [ ] Code passes linting/formatting checks
- [ ] Changes to resources have been tested in our dev environments
- [ ] I have made corresponding changes to the documentation

## Testing

<!-- Detail how the changes have been tested, including any automated or manual tests performed. Include the results of the testing (Screenshots, links to releases, etc.), including any issues or bugs encountered and how they were resolved -->

## Reviewer instructions
<!-- Include any instructions or guidance for reviewers, including specific areas to focus on or areas that require additional attention -->
