### PR TITLE
added defaults for network resource in cluster yaml

### DIFF
--- a/modules/kubernetes_cluster/aws_eks/0.1/facets.yaml
+++ b/modules/kubernetes_cluster/aws_eks/0.1/facets.yaml
@@ -8,6 +8,9 @@ clouds:
 inputs:
   network_details:
     type: "@outputs/aws_vpc"
+    default:
+      resource_type: network
+      resource_name: default
 spec:
   title: Kubernetes Cluster
   description: Specification of the kubernetes cluster for aws eks flavor

--- a/modules/kubernetes_cluster/aws_eks/0.2/facets.yaml
+++ b/modules/kubernetes_cluster/aws_eks/0.2/facets.yaml
@@ -8,6 +8,9 @@ clouds:
 inputs:
   network_details:
     type: "@outputs/aws_vpc"
+    default:
+      resource_type: network
+      resource_name: default
 spec:
   title: Kubernetes Cluster
   description: Specification of the kubernetes cluster for aws eks flavor

--- a/modules/kubernetes_cluster/azure_aks/0.1/facets.yaml
+++ b/modules/kubernetes_cluster/azure_aks/0.1/facets.yaml
@@ -8,6 +8,9 @@ clouds:
 inputs:
   network_details:
     type: "@outputs/azure_vpc"
+    default:
+      resource_type: network
+      resource_name: default
 spec:
   title: Kubernetes Cluster
   description: Specification of the kubernetes cluster for azure aks flavor

--- a/modules/kubernetes_cluster/gcp_gke/0.1/facets.yaml
+++ b/modules/kubernetes_cluster/gcp_gke/0.1/facets.yaml
@@ -8,6 +8,9 @@ clouds:
 inputs:
   network_details:
     type: "@outputs/gcp_vpc"
+    default:
+      resource_type: network
+      resource_name: default
 spec:
   title: Kubernetes Cluster
   description: Specification of the kubernetes cluster for gcp gke flavor

--- a/modules/network/aws_vpc/0.1/facets.yaml
+++ b/modules/network/aws_vpc/0.1/facets.yaml
@@ -1,5 +1,6 @@
 intent: network
 flavor: aws_vpc
+alias-flavors: ["default"]
 version: "0.1"
 description: Adds network - aws vpc flavor
 clouds:


### PR DESCRIPTION
# Description

Added defaults for network so that user gets default as option while creating cluster resource.

## Related issues
Task Id: https://app.clickup.com/t/86cyz54gx

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist
<!-- Please delete options that are not relevant. -->

- [ ] I have created feat/bugfix branch out of `develop` branch
- [ ] Code passes linting/formatting checks
- [ ] Changes to resources have been tested in our dev environments
- [ ] I have made corresponding changes to the documentation

## Testing

<!-- Detail how the changes have been tested, including any automated or manual tests performed. Include the results of the testing (Screenshots, links to releases, etc.), including any issues or bugs encountered and how they were resolved -->

## Reviewer instructions
<!-- Include any instructions or guidance for reviewers, including specific areas to focus on or areas that require additional attention -->
