### PR TITLE
skip base64 encode and secret mig

### DIFF
--- a/modules/kubernetes_secret/k8s/0.3/locals.tf
+++ b/modules/kubernetes_secret/k8s/0.3/locals.tf
@@ -1,0 +1,8 @@
+# Define your locals here
+locals {
+  metadata        = lookup(var.instance, "metadata", {})
+  spec            = lookup(var.instance, "spec", {})
+  advanced_config = lookup(lookup(var.instance, "advanced", {}), "k8s", {})
+  skip_base64_encode = lookup(advanced_config, "skip_base64_encode", false)
+  namespace       = lookup(local.metadata, "namespace", null) == null ? var.environment.namespace : var.instance.metadata.namespace
+}

--- a/modules/kubernetes_secret/k8s/0.3/main.tf
+++ b/modules/kubernetes_secret/k8s/0.3/main.tf
@@ -1,0 +1,50 @@
+# # Define your terraform resources here
+
+module "facets-secret" {
+  source          = "github.com/Facets-cloud/facets-utility-modules//any-k8s-resources"
+  name            = lower(var.instance_name)
+  namespace       = local.namespace
+  advanced_config = {}
+  data = merge(
+    {
+      apiVersion = "v1"
+      kind       = "Secret"
+      metadata = {
+        name        = lower(var.instance_name)
+        namespace   = local.namespace
+        annotations = lookup(local.metadata, "annotations", {})
+        labels      = lookup(local.metadata, "labels", {})
+      }
+    },
+    local.skip_base64_encode ? {
+      data = {
+        for k, v in lookup(local.spec, "data", {}) : v.key => v.value
+      }
+    } : {
+      data = {
+        for k, v in lookup(local.spec, "data", {}) : v.key => base64encode(v.value)
+      }
+    }
+  )
+}
+
+
+# module "facets-secret" {
+#   source          = "github.com/Facets-cloud/facets-utility-modules//any-k8s-resources"
+#   name            = lower(var.instance_name)
+#   namespace       = local.namespace
+#   advanced_config = {}
+#   data = {
+#     apiVersion = "v1"
+#     kind       = "Secret"
+#     metadata = {
+#       name        = lower(var.instance_name)
+#       namespace   = local.namespace
+#       annotations = lookup(var.instance.metadata, "annotations", {})
+#       labels      = lookup(var.instance.metadata, "labels", {})
+#     }
+#     data = {
+#       for k, v in lookup(local.spec, "data", {}) : v.key => local.skip_base64_encode ? v.value : base64encode(v.value)
+#     }
+#   }
+

--- a/modules/kubernetes_secret/k8s/0.3/outputs.tf
+++ b/modules/kubernetes_secret/k8s/0.3/outputs.tf
@@ -1,0 +1,8 @@
+locals {
+  output_attributes = {
+    name = lower(var.instance_name)
+    hash = md5(jsonencode(merge(lookup(local.spec, "data", {}), lookup(local.spec, "json_data", {}))))
+  }
+
+  output_interfaces = {}
+}

--- a/modules/kubernetes_secret/k8s/0.3/variables.tf
+++ b/modules/kubernetes_secret/k8s/0.3/variables.tf
@@ -1,0 +1,39 @@
+variable "cluster" {
+  type = any
+  default = {
+  }
+}
+
+variable "baseinfra" {
+  type = any
+  default = {
+    k8s_details = {
+      registry_secret_objects = []
+    }
+  }
+}
+
+variable "cc_metadata" {
+  type = any
+  default = {
+    tenant_base_domain : "tenant.facets.cloud"
+  }
+}
+
+variable "instance" {
+  type    = any
+  default = {}
+}
+
+variable "instance_name" {
+  type    = string
+  default = "test_instance"
+}
+
+
+variable "environment" {
+  type = any
+  default = {
+    namespace = "default"
+  }
+}


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

When a user supplied a Base64-encoded string for a secret, our module would apply another layer of Base64 encoding. This resulted in a double-encoded value being stored. Consequently, when a pod attempted to read this secret, it would receive the incorrectly encoded value, preventing it from using the actual, intended secret.
To address this, we've introduced a new flag within the module: skip_base64_encoded.
If you are providing a secret value that is already Base64-encoded, you must set the skip_base64_encoded flag to true. This instructs our module to bypass its default Base64 encoding step, ensuring the secret is stored as provided and correctly read by your pods.


## Related issues
<!-- If this PR is related to an existing issue or feature request, please reference clickup task url here. -->

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist
<!-- Please delete options that are not relevant. -->

- [ ] I have created feat/bugfix branch out of `develop` branch
- [ ] Code passes linting/formatting checks
- [ ] Changes to resources have been tested in our dev environments
- [ ] I have made corresponding changes to the documentation

## Testing

<!-- Detail how the changes have been tested, including any automated or manual tests performed. Include the results of the testing (Screenshots, links to releases, etc.), including any issues or bugs encountered and how they were resolved -->

## Reviewer instructions
<!-- Include any instructions or guidance for reviewers, including specific areas to focus on or areas that require additional attention -->
