### PR TITLE
Fix: Correct regex for sidecar env var names to support hyphen

### DIFF
--- a/modules/service/deployment/0.1/facets.yaml
+++ b/modules/service/deployment/0.1/facets.yaml
@@ -921,7 +921,7 @@ spec:
               description: Map of environment variables passed to init container.
               type: object
               patternProperties:
-                "^[a-zA-Z][a-zA-Z0-9_-.]*$":
+                "^[a-zA-Z][a-zA-Z0-9_.-]*$":
                   title: Evironment Variable
                   description: Environment Variable
                   type: string

--- a/modules/service/deployment/0.1/facets.yaml
+++ b/modules/service/deployment/0.1/facets.yaml
@@ -1190,7 +1190,7 @@ spec:
               description: Map of environment variables passed to init container
               type: object
               patternProperties:
-                "^[a-zA-Z][a-zA-Z0-9_-.]*$":
+                "^[a-zA-Z][a-zA-Z0-9_.-]*$":
                   title: Evironment Variable
                   description: Environment Variable
                   type: string


### PR DESCRIPTION
This PR updates the regex pattern for sidecar environment variable keys in the facets.yaml spec to allow hyphens by correcting the pattern to ^[a-zA-Z][a-zA-Z0-9_.-]*$.