### PR TITLE
Network Input in Kafka

### DIFF
--- a/modules/kafka/msk/0.1/facets.yaml
+++ b/modules/kafka/msk/0.1/facets.yaml
@@ -4,6 +4,14 @@ version: "0.1"
 description: Adds Kafka module of MSK flavor
 clouds:
 - aws
+inputs:
+  network_details:
+    type: "@outputs/aws_vpc"
+    displayName: Network
+    optional: false
+    default:
+      resource_type: network
+      resource_name: default
 spec:
   title: Kafka spec
   type: object


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a required "Network" input to the Kafka MSK module, allowing users to specify an AWS VPC resource for network configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->