### PR TITLE
remove cloud_account from gcs

### DIFF
--- a/modules/google_cloud_storage/default/0.2/facets.yaml
+++ b/modules/google_cloud_storage/default/0.2/facets.yaml
@@ -141,11 +141,6 @@ spec:
   - storage_class
   - versioning_enabled
   - uniform_bucket_level_access
-inputs:
-  cloud_account:
-    type: '@outputs/cloud_account'
-    providers:
-    - google
 outputs:
   default:
     type: '@outputs/google_cloud_storage_bucket'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated configuration to remove the cloud account input option for Google Cloud Storage. No changes to outputs or other visible features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->