### PR TITLE
Add Output for GCS bucket

### DIFF
--- a/outputs/google_cloud_storage_bucket/output.facets.yaml
+++ b/outputs/google_cloud_storage_bucket/output.facets.yaml
@@ -14,5 +14,32 @@ out:
         name:
           type: string
           description: The name of the created GCS bucket
+        bucket_url:
+          type: string
+          description: Full URL of the GCS bucket in the format gs://bucket-name
+        bucket_name:
+          type: string
+          description: The name of the created GCS bucket
+        read_only_role:
+          type: string
+          description: GCP IAM role for read-only access to the bucket
+        bucket_location:
+          type: string
+          description: The location of the GCS bucket
+        read_write_role:
+          type: string
+          description: GCP IAM role for read-write access to the bucket
+        bucket_self_link:
+          type: string
+          description: The self link of the GCS bucket
+        bucket_storage_class:
+          type: string
+          description: The storage class of the GCS bucket
+        bucket_iam_condition_title:
+          type: string
+          description: Title for IAM condition restricting access to this bucket
+        bucket_iam_condition_expression:
+          type: string
+          description: Expression for IAM condition restricting access to this bucket
     interfaces: {}
       


### PR DESCRIPTION
Description

  Added missing output attributes to the Google Cloud Storage bucket output configuration file. The output.facets.yaml was
  missing several important attributes that were already defined in the module's outputs.tf file, including IAM roles, bucket
  location, storage class, and IAM condition expressions.

  Related issues

  Type of change

  - Bug fix (non-breaking change which fixes an issue)
  - New feature (non-breaking change which adds functionality)
  - Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - This change requires a documentation update

  Checklist

  - I have created feat/bugfix branch out of develop branch
  - Code passes linting/formatting checks
  - Changes to resources have been tested in our dev environments
  - I have made corresponding changes to the documentation

  Testing

  The changes involve adding missing output attribute definitions to the YAML schema file. These are schema definitions only
  and don't affect runtime behavior. The added attributes match exactly with the outputs already defined in
  modules/google_cloud_storage/default/0.2/outputs.tf.

  Added attributes:
  - bucket_url - GCS bucket URL (gs:// format)
  - bucket_name - Bucket name
  - read_only_role - IAM role for read-only access
  - bucket_location - Bucket location
  - read_write_role - IAM role for read-write access
  - bucket_self_link - Bucket self link
  - bucket_storage_class - Storage class
  - bucket_iam_condition_title - IAM condition title
  - bucket_iam_condition_expression - IAM condition expression

  Reviewer instructions

  Please verify that all output attributes from modules/google_cloud_storage/default/0.2/outputs.tf are now properly reflected
   in outputs/google_cloud_storage_bucket/output.facets.yaml. The descriptions should be clear and accurate for each
  attribute.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Expanded Google Cloud Storage bucket outputs with nine attributes: bucket_url, bucket_name, bucket_location, bucket_storage_class, bucket_self_link, read_only_role, read_write_role, bucket_iam_condition_title, and bucket_iam_condition_expression.
  - Provides richer metadata and IAM context directly in outputs for easier integration and auditing.
- Chores
  - Backward-compatible schema extension with no runtime behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->