### PR TITLE
added include cluster code

### DIFF
--- a/templates/base/network/instances/default.json
+++ b/templates/base/network/instances/default.json
@@ -5,7 +5,9 @@
   "ui": {
     "base_resource": true
   },
-  "spec": {},
+  "spec": {
+    "include_cluster_code": true
+  },
   "provided": false,
   "disabled": false,
   "advanced": {


### PR DESCRIPTION
# Description
The problem was that the kubernetes cluster by default uses the include_cluster_code_in_name attribute to include the cluster code, but the network module base template does not by default add the include cluster code configuration which cause the inconsistency in the tags which are present in the network resources like subnet etc. 

This was breaking in karpenter since we are cluster_name in the subnet selector terms but in the subnet tags the cluster name was incorrect as it does not include the cluster code.


<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Related issues
<!-- If this PR is related to an existing issue or feature request, please reference clickup task url here. -->

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist
<!-- Please delete options that are not relevant. -->

- [ ] I have created feat/bugfix branch out of `develop` branch
- [ ] Code passes linting/formatting checks
- [ ] Changes to resources have been tested in our dev environments
- [ ] I have made corresponding changes to the documentation

## Testing

<!-- Detail how the changes have been tested, including any automated or manual tests performed. Include the results of the testing (Screenshots, links to releases, etc.), including any issues or bugs encountered and how they were resolved -->

## Reviewer instructions
<!-- Include any instructions or guidance for reviewers, including specific areas to focus on or areas that require additional attention -->
