### PR TITLE
Live Tab shows k8s dashboard

### DIFF
--- a/modules/service/cronjob/0.1/facets.yaml
+++ b/modules/service/cronjob/0.1/facets.yaml
@@ -19,6 +19,8 @@ metadata:
       type: string
       title: Namespace
       description: Namespace in which cronjob should be deployed
+controlPlaneUISettings:
+  enableKubernetesExplorer: true
 spec:
   title: Cronjob flavor of service
   type: object

--- a/modules/service/deployment/0.1/facets.yaml
+++ b/modules/service/deployment/0.1/facets.yaml
@@ -20,6 +20,8 @@ metadata:
       type: string
       title: Namespace
       description: Namespace in which deployment should be deployed
+controlPlaneUISettings:
+  enableKubernetesExplorer: true
 spec:
   title: K8s flavor of service
   type: object

--- a/modules/service/job/0.1/facets.yaml
+++ b/modules/service/job/0.1/facets.yaml
@@ -19,6 +19,8 @@ metadata:
       type: string
       title: Namespace
       description: Namespace in which job should be deployed
+controlPlaneUISettings:
+  enableKubernetesExplorer: true
 spec:
   title: K8s flavor of service
   type: object

--- a/modules/service/statefulset/0.1/facets.yaml
+++ b/modules/service/statefulset/0.1/facets.yaml
@@ -19,6 +19,8 @@ metadata:
       type: string
       title: Namespace
       description: Namespace in which statefulset should be deployed
+controlPlaneUISettings:
+  enableKubernetesExplorer: true
 spec:
   title: K8s flavor of service
   type: object


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional Control Plane UI setting to enable the Kubernetes Explorer. Available for CronJob, Deployment, Job, and StatefulSet services, allowing admins to turn on the explorer without impacting existing configurations. Default behavior remains unchanged unless explicitly enabled. No validation rules or workflows were altered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->