### PR TITLE
added secret-copier labels

### DIFF
--- a/modules/artifactories/default/0.1/registry_secret.tf
+++ b/modules/artifactories/default/0.1/registry_secret.tf
@@ -3,7 +3,7 @@ resource "kubernetes_secret_v1" "registry_secret" {
   metadata {
     name      = each.value.name
     namespace = local.namespace
-    labels    = lookup(local.metadata, "labels", {})
+    labels    = merge(lookup(local.metadata, "labels", {}), {"secret-copier" = "yes"})
   }
   data = {
     ".dockerconfigjson" : each.value.dockerconfigjson


### PR DESCRIPTION
# Description

the artifactories module only uses the labels from metadata.labels  but it doesn't automatically add the secret-copier: yes label.

When we created the artifactories resource in the blueprint the secret was created without secret-copier yes labels hence the secret copier which is running was not able to copy the secret in the new ns. 


<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Related issues
<!-- If this PR is related to an existing issue or feature request, please reference clickup task url here. -->

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist
<!-- Please delete options that are not relevant. -->

- [ ] I have created feat/bugfix branch out of `develop` branch
- [ ] Code passes linting/formatting checks
- [ ] Changes to resources have been tested in our dev environments
- [ ] I have made corresponding changes to the documentation

## Testing

<!-- Detail how the changes have been tested, including any automated or manual tests performed. Include the results of the testing (Screenshots, links to releases, etc.), including any issues or bugs encountered and how they were resolved -->

## Reviewer instructions
<!-- Include any instructions or guidance for reviewers, including specific areas to focus on or areas that require additional attention -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Kubernetes secret configuration to support secret copying operations by adding appropriate metadata labels. This enables improved secret management capabilities in the infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->