### PR TITLE
fix initalDelaySeonds for deploy/sts

### DIFF
--- a/modules/service/deployment/0.1/facets.yaml
+++ b/modules/service/deployment/0.1/facets.yaml
@@ -419,7 +419,7 @@ spec:
               - PortCheck
               - HttpCheck
               - ExecCheck
-            startup_start_up_time:
+            startup_initial_delay_seconds:
               type: integer
               title: Startup Start-Up Time
               default: 10

--- a/modules/service/statefulset/0.1/facets.yaml
+++ b/modules/service/statefulset/0.1/facets.yaml
@@ -409,7 +409,7 @@ spec:
               - PortCheck
               - HttpCheck
               - ExecCheck
-            startup_start_up_time:
+            startup_initial_delay_seconds:
               type: integer
               title: Startup Start-Up Time
               default: 10


### PR DESCRIPTION
# Description

- Fixed incorrect schema field name for startup probe's initialDelaySeconds in facets.yaml. Changed         
  startup_start_up_time to startup_initial_delay_seconds to match what the Helm template (_helpers.tpl) actually reads.
  
  Context                                                                                                     

  The Helm template at _helpers.tpl:320 reads:                                                                  
  {{ default .Values.spec.runtime.health_checks.start_up_time
  .Values.spec.runtime.health_checks.startup_initial_delay_seconds | default 10 }} 
  
  The facets.yaml schema was defining the field as startup_start_up_time, which is not consumed by the template.
   This caused any value set via the UI form to be silently ignored, and the startup probe would always fall    
  back to the default of 10.
  
  Any service that configured startup_start_up_time via the form was not getting the correct initialDelaySeconds
 value applied to the startup probe — unless they also happened to set startup_initial_delay_seconds directly
  in JSON mode.                                                                                            

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Related issues
<!-- If this PR is related to an existing issue or feature request, please reference clickup task url here. -->

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist
<!-- Please delete options that are not relevant. -->

- [ ] I have created feat/bugfix branch out of `develop` branch
- [ ] Code passes linting/formatting checks
- [ ] Changes to resources have been tested in our dev environments
- [ ] I have made corresponding changes to the documentation

## Testing

<!-- Detail how the changes have been tested, including any automated or manual tests performed. Include the results of the testing (Screenshots, links to releases, etc.), including any issues or bugs encountered and how they were resolved -->

## Reviewer instructions
<!-- Include any instructions or guidance for reviewers, including specific areas to focus on or areas that require additional attention -->
