### PR TITLE
fix(service): add missing failure/success threshold fields to health checks

### DIFF
--- a/modules/service/deployment/0.1/facets.yaml
+++ b/modules/service/deployment/0.1/facets.yaml
@@ -328,6 +328,32 @@ spec:
                 values: ["ExecCheck"]
               description: Commands for readiness check
               x-ui-override-disable: true
+            readiness_failure_threshold:
+              type: integer
+              title: Readiness Failure Threshold
+              default: 10
+              minimum: 1
+              maximum: 100
+              x-ui-placeholder: "Enter readiness failure threshold"
+              x-ui-error-message: "Value doesn't match pattern, accepted values are
+                from 1-100"
+              x-ui-visible-if:
+                field: spec.runtime.health_checks.readiness_check_type
+                values: ["PortCheck", "HttpCheck", "ExecCheck"]
+              description: Number of consecutive failures before marking unhealthy
+            readiness_success_threshold:
+              type: integer
+              title: Readiness Success Threshold
+              default: 1
+              minimum: 1
+              maximum: 100
+              x-ui-placeholder: "Enter readiness success threshold"
+              x-ui-error-message: "Value doesn't match pattern, accepted values are
+                from 1-100"
+              x-ui-visible-if:
+                field: spec.runtime.health_checks.readiness_check_type
+                values: ["PortCheck", "HttpCheck", "ExecCheck"]
+              description: Number of consecutive successes before marking healthy
             liveness_check_type:
               type: string
               title: Liveness Check Type
@@ -402,13 +428,39 @@ spec:
             liveness_exec_command:
               type: array
               title: Liveness Exec Command
-              x-ui-placeholder: "Add each command argument as a new entry" 
+              x-ui-placeholder: "Add each command argument as a new entry"
               x-ui-error-message: "Enter each command/argument in a separate line"
               x-ui-visible-if:
                 field: "spec.runtime.health_checks.liveness_check_type"
                 values: ["ExecCheck"]
               description: Commands for liveness
               x-ui-override-disable: true
+            liveness_failure_threshold:
+              type: integer
+              title: Liveness Failure Threshold
+              default: 10
+              minimum: 1
+              maximum: 100
+              x-ui-placeholder: "Enter liveness failure threshold"
+              x-ui-error-message: "Value doesn't match pattern, accepted values are
+                from 1-100"
+              x-ui-visible-if:
+                field: "spec.runtime.health_checks.liveness_check_type"
+                values: ["PortCheck", "HttpCheck", "ExecCheck"]
+              description: Number of consecutive failures before marking unhealthy
+            liveness_success_threshold:
+              type: integer
+              title: Liveness Success Threshold
+              default: 1
+              minimum: 1
+              maximum: 100
+              x-ui-placeholder: "Enter liveness success threshold"
+              x-ui-error-message: "Value doesn't match pattern, accepted values are
+                from 1-100"
+              x-ui-visible-if:
+                field: "spec.runtime.health_checks.liveness_check_type"
+                values: ["PortCheck", "HttpCheck", "ExecCheck"]
+              description: Number of consecutive successes before marking healthy
             startup_check_type:
               type: string
               title: Startup Check Type
@@ -498,6 +550,32 @@ spec:
                 values: ["ExecCheck"]
               description: Commands for startup check
               x-ui-override-disable: true
+            startup_failure_threshold:
+              type: integer
+              title: Startup Failure Threshold
+              default: 10
+              minimum: 1
+              maximum: 100
+              x-ui-placeholder: "Enter startup failure threshold"
+              x-ui-error-message: "Value doesn't match pattern, accepted values are
+                from 1-100"
+              x-ui-visible-if:
+                field: spec.runtime.health_checks.startup_check_type
+                values: ["PortCheck", "HttpCheck", "ExecCheck"]
+              description: Number of consecutive failures before marking unhealthy
+            startup_success_threshold:
+              type: integer
+              title: Startup Success Threshold
+              default: 1
+              minimum: 1
+              maximum: 100
+              x-ui-placeholder: "Enter startup success threshold"
+              x-ui-error-message: "Value doesn't match pattern, accepted values are
+                from 1-100"
+              x-ui-visible-if:
+                field: spec.runtime.health_checks.startup_check_type
+                values: ["PortCheck", "HttpCheck", "ExecCheck"]
+              description: Number of consecutive successes before marking healthy
         autoscaling:
           type: object
           title: Autoscaling
@@ -1584,6 +1662,32 @@ spec:
                         values: ["ExecCheck"]
                       description: Commands for readiness check
                       x-ui-override-disable: true
+                    readiness_failure_threshold:
+                      type: integer
+                      title: Readiness Failure Threshold
+                      default: 10
+                      minimum: 1
+                      maximum: 100
+                      x-ui-placeholder: "Enter readiness failure threshold"
+                      x-ui-error-message: "Value doesn't match pattern, accepted values
+                        are from 1-100"
+                      x-ui-visible-if:
+                        field: spec.sidecars.{{this}}.runtime.health_checks.readiness_check_type
+                        values: ["PortCheck", "HttpCheck", "ExecCheck"]
+                      description: Number of consecutive failures before marking unhealthy
+                    readiness_success_threshold:
+                      type: integer
+                      title: Readiness Success Threshold
+                      default: 1
+                      minimum: 1
+                      maximum: 100
+                      x-ui-placeholder: "Enter readiness success threshold"
+                      x-ui-error-message: "Value doesn't match pattern, accepted values
+                        are from 1-100"
+                      x-ui-visible-if:
+                        field: spec.sidecars.{{this}}.runtime.health_checks.readiness_check_type
+                        values: ["PortCheck", "HttpCheck", "ExecCheck"]
+                      description: Number of consecutive successes before marking healthy
                     liveness_check_type:
                       type: string
                       title: Liveness Check Type
@@ -1653,6 +1757,32 @@ spec:
                         values: ["ExecCheck"]
                       description: Commands for liveness
                       x-ui-override-disable: true
+                    liveness_failure_threshold:
+                      type: integer
+                      title: Liveness Failure Threshold
+                      default: 10
+                      minimum: 1
+                      maximum: 100
+                      x-ui-placeholder: "Enter liveness failure threshold"
+                      x-ui-error-message: "Value doesn't match pattern, accepted values
+                        are from 1-100"
+                      x-ui-visible-if:
+                        field: "spec.sidecars.{{this}}.runtime.health_checks.liveness_check_type"
+                        values: ["PortCheck", "HttpCheck", "ExecCheck"]
+                      description: Number of consecutive failures before marking unhealthy
+                    liveness_success_threshold:
+                      type: integer
+                      title: Liveness Success Threshold
+                      default: 1
+                      minimum: 1
+                      maximum: 100
+                      x-ui-placeholder: "Enter liveness success threshold"
+                      x-ui-error-message: "Value doesn't match pattern, accepted values
+                        are from 1-100"
+                      x-ui-visible-if:
+                        field: "spec.sidecars.{{this}}.runtime.health_checks.liveness_check_type"
+                        values: ["PortCheck", "HttpCheck", "ExecCheck"]
+                      description: Number of consecutive successes before marking healthy
                     startup_check_type:
                       type: string
                       title: Startup Check Type
@@ -1722,6 +1852,32 @@ spec:
                         values: ["ExecCheck"]
                       description: Commands for startup check
                       x-ui-override-disable: true
+                    startup_failure_threshold:
+                      type: integer
+                      title: Startup Failure Threshold
+                      default: 10
+                      minimum: 1
+                      maximum: 100
+                      x-ui-placeholder: "Enter startup failure threshold"
+                      x-ui-error-message: "Value doesn't match pattern, accepted values
+                        are from 1-100"
+                      x-ui-visible-if:
+                        field: spec.sidecars.{{this}}.runtime.health_checks.startup_check_type
+                        values: ["PortCheck", "HttpCheck", "ExecCheck"]
+                      description: Number of consecutive failures before marking unhealthy
+                    startup_success_threshold:
+                      type: integer
+                      title: Startup Success Threshold
+                      default: 1
+                      minimum: 1
+                      maximum: 100
+                      x-ui-placeholder: "Enter startup success threshold"
+                      x-ui-error-message: "Value doesn't match pattern, accepted values
+                        are from 1-100"
+                      x-ui-visible-if:
+                        field: spec.sidecars.{{this}}.runtime.health_checks.startup_check_type
+                        values: ["PortCheck", "HttpCheck", "ExecCheck"]
+                      description: Number of consecutive successes before marking healthy
                     port:
                       type: string
                       title: Health Check Port

--- a/modules/service/statefulset/0.1/facets.yaml
+++ b/modules/service/statefulset/0.1/facets.yaml
@@ -303,6 +303,38 @@ spec:
               items:
                 type: string
               x-ui-override-disable: true
+            readiness_failure_threshold:
+              type: integer
+              title: Readiness Failure Threshold
+              default: 10
+              minimum: 1
+              maximum: 100
+              x-ui-placeholder: "Enter readiness failure threshold"
+              x-ui-error-message: "Value doesn't match pattern, accepted values are
+                from 1-100"
+              x-ui-visible-if:
+                field: spec.runtime.health_checks.readiness_check_type
+                values:
+                - PortCheck
+                - HttpCheck
+                - ExecCheck
+              description: Number of consecutive failures before marking unhealthy
+            readiness_success_threshold:
+              type: integer
+              title: Readiness Success Threshold
+              default: 1
+              minimum: 1
+              maximum: 100
+              x-ui-placeholder: "Enter readiness success threshold"
+              x-ui-error-message: "Value doesn't match pattern, accepted values are
+                from 1-100"
+              x-ui-visible-if:
+                field: spec.runtime.health_checks.readiness_check_type
+                values:
+                - PortCheck
+                - HttpCheck
+                - ExecCheck
+              description: Number of consecutive successes before marking healthy
             liveness_check_type:
               type: string
               title: Liveness Check Type
@@ -399,6 +431,38 @@ spec:
               items:
                 type: string
               x-ui-override-disable: true
+            liveness_failure_threshold:
+              type: integer
+              title: Liveness Failure Threshold
+              default: 10
+              minimum: 1
+              maximum: 100
+              x-ui-placeholder: "Enter liveness failure threshold"
+              x-ui-error-message: "Value doesn't match pattern, accepted values are
+                from 1-100"
+              x-ui-visible-if:
+                field: spec.runtime.health_checks.liveness_check_type
+                values:
+                - PortCheck
+                - HttpCheck
+                - ExecCheck
+              description: Number of consecutive failures before marking unhealthy
+            liveness_success_threshold:
+              type: integer
+              title: Liveness Success Threshold
+              default: 1
+              minimum: 1
+              maximum: 100
+              x-ui-placeholder: "Enter liveness success threshold"
+              x-ui-error-message: "Value doesn't match pattern, accepted values are
+                from 1-100"
+              x-ui-visible-if:
+                field: spec.runtime.health_checks.liveness_check_type
+                values:
+                - PortCheck
+                - HttpCheck
+                - ExecCheck
+              description: Number of consecutive successes before marking healthy
             startup_check_type:
               type: string
               title: Startup Check Type
@@ -502,6 +566,38 @@ spec:
                 - ExecCheck
               description: Commands for startup check
               x-ui-override-disable: true
+            startup_failure_threshold:
+              type: integer
+              title: Startup Failure Threshold
+              default: 10
+              minimum: 1
+              maximum: 100
+              x-ui-placeholder: "Enter startup failure threshold"
+              x-ui-error-message: "Value doesn't match pattern, accepted values are
+                from 1-100"
+              x-ui-visible-if:
+                field: spec.runtime.health_checks.startup_check_type
+                values:
+                - PortCheck
+                - HttpCheck
+                - ExecCheck
+              description: Number of consecutive failures before marking unhealthy
+            startup_success_threshold:
+              type: integer
+              title: Startup Success Threshold
+              default: 1
+              minimum: 1
+              maximum: 100
+              x-ui-placeholder: "Enter startup success threshold"
+              x-ui-error-message: "Value doesn't match pattern, accepted values are
+                from 1-100"
+              x-ui-visible-if:
+                field: spec.runtime.health_checks.startup_check_type
+                values:
+                - PortCheck
+                - HttpCheck
+                - ExecCheck
+              description: Number of consecutive successes before marking healthy
           required:
           - readiness_port
           - readiness_url
@@ -1606,6 +1702,38 @@ spec:
                       items:
                         type: string
                       x-ui-override-disable: true
+                    readiness_failure_threshold:
+                      type: integer
+                      title: Readiness Failure Threshold
+                      default: 10
+                      minimum: 1
+                      maximum: 100
+                      x-ui-placeholder: "Enter readiness failure threshold"
+                      x-ui-error-message: "Value doesn't match pattern, accepted values
+                        are from 1-100"
+                      x-ui-visible-if:
+                        field: spec.sidecars.{{this}}.runtime.health_checks.readiness_check_type
+                        values:
+                        - PortCheck
+                        - HttpCheck
+                        - ExecCheck
+                      description: Number of consecutive failures before marking unhealthy
+                    readiness_success_threshold:
+                      type: integer
+                      title: Readiness Success Threshold
+                      default: 1
+                      minimum: 1
+                      maximum: 100
+                      x-ui-placeholder: "Enter readiness success threshold"
+                      x-ui-error-message: "Value doesn't match pattern, accepted values
+                        are from 1-100"
+                      x-ui-visible-if:
+                        field: spec.sidecars.{{this}}.runtime.health_checks.readiness_check_type
+                        values:
+                        - PortCheck
+                        - HttpCheck
+                        - ExecCheck
+                      description: Number of consecutive successes before marking healthy
                     liveness_check_type:
                       type: string
                       title: Liveness Check Type
@@ -1688,6 +1816,38 @@ spec:
                       items:
                         type: string
                       x-ui-override-disable: true
+                    liveness_failure_threshold:
+                      type: integer
+                      title: Liveness Failure Threshold
+                      default: 10
+                      minimum: 1
+                      maximum: 100
+                      x-ui-placeholder: "Enter liveness failure threshold"
+                      x-ui-error-message: "Value doesn't match pattern, accepted values
+                        are from 1-100"
+                      x-ui-visible-if:
+                        field: spec.sidecars.{{this}}.runtime.health_checks.liveness_check_type
+                        values:
+                        - PortCheck
+                        - HttpCheck
+                        - ExecCheck
+                      description: Number of consecutive failures before marking unhealthy
+                    liveness_success_threshold:
+                      type: integer
+                      title: Liveness Success Threshold
+                      default: 1
+                      minimum: 1
+                      maximum: 100
+                      x-ui-placeholder: "Enter liveness success threshold"
+                      x-ui-error-message: "Value doesn't match pattern, accepted values
+                        are from 1-100"
+                      x-ui-visible-if:
+                        field: spec.sidecars.{{this}}.runtime.health_checks.liveness_check_type
+                        values:
+                        - PortCheck
+                        - HttpCheck
+                        - ExecCheck
+                      description: Number of consecutive successes before marking healthy
                     startup_check_type:
                       type: string
                       title: Startup Check Type
@@ -1768,6 +1928,38 @@ spec:
                         - ExecCheck
                       description: Commands for startup check
                       x-ui-override-disable: true
+                    startup_failure_threshold:
+                      type: integer
+                      title: Startup Failure Threshold
+                      default: 10
+                      minimum: 1
+                      maximum: 100
+                      x-ui-placeholder: "Enter startup failure threshold"
+                      x-ui-error-message: "Value doesn't match pattern, accepted values
+                        are from 1-100"
+                      x-ui-visible-if:
+                        field: spec.sidecars.{{this}}.runtime.health_checks.startup_check_type
+                        values:
+                        - PortCheck
+                        - HttpCheck
+                        - ExecCheck
+                      description: Number of consecutive failures before marking unhealthy
+                    startup_success_threshold:
+                      type: integer
+                      title: Startup Success Threshold
+                      default: 1
+                      minimum: 1
+                      maximum: 100
+                      x-ui-placeholder: "Enter startup success threshold"
+                      x-ui-error-message: "Value doesn't match pattern, accepted values
+                        are from 1-100"
+                      x-ui-visible-if:
+                        field: spec.sidecars.{{this}}.runtime.health_checks.startup_check_type
+                        values:
+                        - PortCheck
+                        - HttpCheck
+                        - ExecCheck
+                      description: Number of consecutive successes before marking healthy
                     port:
                       type: string
                       title: Health Check Port


### PR DESCRIPTION
## Summary
- Added missing `*_failure_threshold` and `*_success_threshold` form fields to the service deployment `facets.yaml`
- These fields are read by the helm template (`_helpers.tpl`) but were never exposed in the form, so the defaults (10 for failure, 1 for success) always applied with no way for users to configure them

## Fields added

**Main container health_checks:**
- `readiness_failure_threshold`, `readiness_success_threshold`
- `liveness_failure_threshold`, `liveness_success_threshold`
- `startup_failure_threshold`, `startup_success_threshold`

**Sidecar health_checks:**
- `readiness_failure_threshold`, `readiness_success_threshold`
- `liveness_failure_threshold`, `liveness_success_threshold`
- `startup_failure_threshold`, `startup_success_threshold`

## Related
- Companion PR in facets-iac: fixes sidecar template to use per-probe timing keys (`liveness_start_up_time`, `readiness_timeout`, etc.) matching this form

## Test plan
- [ ] Verify the new threshold fields render correctly in the UI under each check type
- [ ] Verify visibility toggles work (fields only show when respective check type is not None)
- [ ] Deploy a service with custom threshold values and confirm they appear in the K8s manifest

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable failure and success thresholds for readiness, liveness, and startup health checks. These thresholds can now be set for both main deployments and sidecars to control consecutive failure and success counts (1-100).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->