### PR TITLE
feat(ingress/fabric_legacy): expose legacy_resource_details from utility module

### DIFF
--- a/modules/ingress/nginx_gateway_fabric_legacy_aws/1.0/outputs.tf
+++ b/modules/ingress/nginx_gateway_fabric_legacy_aws/1.0/outputs.tf
@@ -88,3 +88,7 @@ output "cloud_provider" {
   value       = module.nginx_gateway_fabric.cloud_provider
   description = "Detected cloud provider (AWS, GCP, AZURE)"
 }
+
+output "legacy_resource_details" {
+  value = module.nginx_gateway_fabric.legacy_resource_details
+}

--- a/modules/ingress/nginx_gateway_fabric_legacy_azure/1.0/outputs.tf
+++ b/modules/ingress/nginx_gateway_fabric_legacy_azure/1.0/outputs.tf
@@ -88,3 +88,7 @@ output "cloud_provider" {
   value       = module.nginx_gateway_fabric.cloud_provider
   description = "Detected cloud provider (AWS, GCP, AZURE)"
 }
+
+output "legacy_resource_details" {
+  value = module.nginx_gateway_fabric.legacy_resource_details
+}

--- a/modules/ingress/nginx_gateway_fabric_legacy_gcp/1.0/outputs.tf
+++ b/modules/ingress/nginx_gateway_fabric_legacy_gcp/1.0/outputs.tf
@@ -88,3 +88,7 @@ output "cloud_provider" {
   value       = module.nginx_gateway_fabric.cloud_provider
   description = "Detected cloud provider (AWS, GCP, AZURE)"
 }
+
+output "legacy_resource_details" {
+  value = module.nginx_gateway_fabric.legacy_resource_details
+}


### PR DESCRIPTION
## Summary
- Re-exports `module.nginx_gateway_fabric.legacy_resource_details` from the three legacy fabric wrapper flavors (`aws`, `azure`, `gcp`).
- Required because Terraform module outputs do **not** auto-passthrough — without these declarations, the utility module's `legacy_resource_details` (added in [facets-utility-modules#35](https://github.com/Facets-cloud/facets-utility-modules/pull/35)) is invisible to consumers.
- Downstream effect: `level2/legacy.tf` in `facets-iac` does `lookup(local.module_<key>, "legacy_resource_details", [])` — until this output exists on the wrapper it falls back to `[]` and the Facets UI shows nothing for ingress resource values (basic auth password, base domain, per-rule domains).

## Files
- `modules/ingress/nginx_gateway_fabric_legacy_aws/1.0/outputs.tf`
- `modules/ingress/nginx_gateway_fabric_legacy_azure/1.0/outputs.tf`
- `modules/ingress/nginx_gateway_fabric_legacy_gcp/1.0/outputs.tf`

Each gets a 4-line addition:

```hcl
output "legacy_resource_details" {
  value = module.nginx_gateway_fabric.legacy_resource_details
}
```

## Test plan
- [ ] Republish the wrapper module via the Facets control plane after merge so the S3 zip picks up the new output.
- [ ] Trigger a release on an environment using `nginx_gateway_fabric_legacy_aws` and confirm the Facets UI ingress resource-values panel now shows: Basic Authentication Password (when `basic_auth: true`), Base Domain, and one row per rule.
- [ ] Verify `terraform output -json | jq '.legacy_resource_details.value'` after apply contains entries with `resource_type = "ingress"` / `resource_type = "ingress_rules_infra"`.
- [ ] Repeat smoke test on azure and gcp flavors.
- [ ] Confirm no "Provider produced inconsistent final plan" error on first apply (when basic_auth password is generated).

## Dependency
Depends on [facets-utility-modules#35](https://github.com/Facets-cloud/facets-utility-modules/pull/35) which adds `legacy_resource_details` to the underlying utility module. That PR is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)