### PR TITLE
feat(ingress/fabric_legacy): expose legacy_resource_details from utility module (#548)

### DIFF
--- a/modules/ingress/nginx_gateway_fabric_legacy_aws/1.0/outputs.tf
+++ b/modules/ingress/nginx_gateway_fabric_legacy_aws/1.0/outputs.tf
@@ -88,3 +88,7 @@ output "cloud_provider" {
   value       = module.nginx_gateway_fabric.cloud_provider
   description = "Detected cloud provider (AWS, GCP, AZURE)"
 }
+
+output "legacy_resource_details" {
+  value = module.nginx_gateway_fabric.legacy_resource_details
+}

--- a/modules/ingress/nginx_gateway_fabric_legacy_azure/1.0/outputs.tf
+++ b/modules/ingress/nginx_gateway_fabric_legacy_azure/1.0/outputs.tf
@@ -88,3 +88,7 @@ output "cloud_provider" {
   value       = module.nginx_gateway_fabric.cloud_provider
   description = "Detected cloud provider (AWS, GCP, AZURE)"
 }
+
+output "legacy_resource_details" {
+  value = module.nginx_gateway_fabric.legacy_resource_details
+}

--- a/modules/ingress/nginx_gateway_fabric_legacy_gcp/1.0/outputs.tf
+++ b/modules/ingress/nginx_gateway_fabric_legacy_gcp/1.0/outputs.tf
@@ -88,3 +88,7 @@ output "cloud_provider" {
   value       = module.nginx_gateway_fabric.cloud_provider
   description = "Detected cloud provider (AWS, GCP, AZURE)"
 }
+
+output "legacy_resource_details" {
+  value = module.nginx_gateway_fabric.legacy_resource_details
+}


### PR DESCRIPTION
## Summary
Cherry-pick of #548 from `develop` to `master`.

Re-exports `module.nginx_gateway_fabric.legacy_resource_details` from the three legacy fabric wrapper flavors (`aws`, `azure`, `gcp`). Required because Terraform module outputs do not auto-passthrough — without these declarations the utility module's `legacy_resource_details` output is invisible to consumers, and `level2/legacy.tf` in `facets-iac` falls back to `[]`, leaving the Facets UI ingress resource-values panel empty.

## Files
- `modules/ingress/nginx_gateway_fabric_legacy_aws/1.0/outputs.tf`
- `modules/ingress/nginx_gateway_fabric_legacy_azure/1.0/outputs.tf`
- `modules/ingress/nginx_gateway_fabric_legacy_gcp/1.0/outputs.tf`

Each gets:

```hcl
output "legacy_resource_details" {
  value = module.nginx_gateway_fabric.legacy_resource_details
}
```

## Test plan
- [ ] Republish the wrapper module via the Facets control plane after merge so the S3 zip picks up the new output.
- [ ] Trigger a release on an environment using `nginx_gateway_fabric_legacy_aws` and confirm the Facets UI ingress resource-values panel now shows: Basic Authentication Password (when `basic_auth: true`), Base Domain, and one row per rule.
- [ ] Repeat smoke test on azure and gcp flavors.

## Dependency
Depends on [facets-utility-modules#35](https://github.com/Facets-cloud/facets-utility-modules/pull/35) (merged) which adds `legacy_resource_details` to the underlying utility module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added legacy resource details output for NGINX gateway deployments across AWS, Azure, and GCP cloud providers, enabling users to access comprehensive information about legacy resources in their gateway configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->