### PR TITLE
feat(ingress): expose helm_release_name_override on legacy nginx_gateway_fabric (#550)

### DIFF
--- a/modules/ingress/nginx_gateway_fabric_legacy_aws/1.0/facets.yaml
+++ b/modules/ingress/nginx_gateway_fabric_legacy_aws/1.0/facets.yaml
@@ -843,24 +843,24 @@ spec:
       title: Proxy Connect Timeout
       description: Timeout for establishing connections to upstream services (e.g., 60s, 1m). Applies gateway-wide to all routes.
       pattern: ^\d+[smh]?$
-      default: 60s
-      x-ui-placeholder: 60s
+      default: 300s
+      x-ui-placeholder: 300s
       x-ui-toggle: true
     proxy_read_timeout:
       type: string
       title: Proxy Read Timeout
       description: Timeout for reading responses from upstream services. Applies gateway-wide to all routes.
       pattern: ^\d+[smh]?$
-      default: 60s
-      x-ui-placeholder: 60s
+      default: 300s
+      x-ui-placeholder: 300s
       x-ui-toggle: true
     proxy_send_timeout:
       type: string
       title: Proxy Send Timeout
       description: Timeout for transmitting requests to upstream services. Applies gateway-wide to all routes.
       pattern: ^\d+[smh]?$
-      default: 60s
-      x-ui-placeholder: 60s
+      default: 300s
+      x-ui-placeholder: 300s
       x-ui-toggle: true
     helm_values:
       type: object

--- a/modules/ingress/nginx_gateway_fabric_legacy_aws/1.0/facets.yaml
+++ b/modules/ingress/nginx_gateway_fabric_legacy_aws/1.0/facets.yaml
@@ -48,6 +48,15 @@ spec:
       title: Disable Base Domain
       description: Disable automatic creation of base domain for this gateway
       default: false
+    helm_release_name_override:
+      type: string
+      title: Helm Release Name Override
+      description: Advanced. Override the Helm release name for this gateway. Leave empty to keep the default (truncated instance/namespace name). Must be a DNS-1123 label (lowercase alphanumerics and hyphens, starting/ending with alphanumeric) and at most 34 characters. Changing this on an existing instance will recreate the release.
+      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+      maxLength: 34
+      x-ui-toggle: true
+      x-ui-placeholder: "e.g. my-gateway-stable"
+      x-ui-error-message: "Must be lowercase alphanumeric with hyphens, start/end with alphanumeric, and at most 34 characters."
     domains:
       title: Domains
       description: Map of domain key to rules
@@ -616,26 +625,30 @@ spec:
                   type: string
                   title: Mirror Service Namespace
                   description: Namespace of the mirror service
-            timeouts:
+            nginx_timeouts:
               type: object
-              title: Request Timeouts
-              description: Configure request and backend timeouts
+              title: Proxy Timeouts (per-rule override)
+              description: Override the gateway-wide proxy_{connect,read,send}_timeout for this route. Rendered via NGF SnippetsFilter at http.server.location. Leave a field empty to inherit the instance default.
               x-ui-toggle: true
               properties:
-                request:
+                proxy_connect_timeout:
                   type: string
-                  title: Request Timeout
-                  description: Total request timeout (e.g., 30s, 1m, 5m)
-                  pattern: ^\d+[smh]$
-                  default: 300s
-                  x-ui-placeholder: "300s"
-                backend_request:
+                  title: Proxy Connect Timeout
+                  description: Override proxy_connect_timeout for this route (e.g., 60s, 5m). Empty = inherit instance default.
+                  pattern: ^\d+[smh]?$
+                  x-ui-placeholder: 300s
+                proxy_read_timeout:
                   type: string
-                  title: Backend Request Timeout
-                  description: Backend response timeout (e.g., 30s, 1m, 5m)
-                  default: 300s
-                  pattern: ^\d+[smh]$
-                  x-ui-placeholder: "300s"
+                  title: Proxy Read Timeout
+                  description: Override proxy_read_timeout for this route (e.g., 60s, 5m). Empty = inherit instance default.
+                  pattern: ^\d+[smh]?$
+                  x-ui-placeholder: 300s
+                proxy_send_timeout:
+                  type: string
+                  title: Proxy Send Timeout
+                  description: Override proxy_send_timeout for this route (e.g., 60s, 5m). Empty = inherit instance default.
+                  pattern: ^\d+[smh]?$
+                  x-ui-placeholder: 300s
             cors:
               type: object
               title: CORS Configuration
@@ -797,7 +810,7 @@ spec:
             - path
             - path_type
             - method
-            - timeouts
+            - nginx_timeouts
             - cors
             - header_matches
             - query_param_matches
@@ -820,10 +833,34 @@ spec:
     body_size:
       type: string
       title: Max Body Size
-      description: Maximum allowed size of the client request body (e.g., 150m, 1g)
+      description: Maximum allowed size of the client request body (e.g., 1m, 1g)
       pattern: ^\d{1,4}(k|m|g)?$
       default: 150m
       x-ui-placeholder: 150m
+      x-ui-toggle: true
+    proxy_connect_timeout:
+      type: string
+      title: Proxy Connect Timeout
+      description: Timeout for establishing connections to upstream services (e.g., 60s, 1m). Applies gateway-wide to all routes.
+      pattern: ^\d+[smh]?$
+      default: 60s
+      x-ui-placeholder: 60s
+      x-ui-toggle: true
+    proxy_read_timeout:
+      type: string
+      title: Proxy Read Timeout
+      description: Timeout for reading responses from upstream services. Applies gateway-wide to all routes.
+      pattern: ^\d+[smh]?$
+      default: 60s
+      x-ui-placeholder: 60s
+      x-ui-toggle: true
+    proxy_send_timeout:
+      type: string
+      title: Proxy Send Timeout
+      description: Timeout for transmitting requests to upstream services. Applies gateway-wide to all routes.
+      pattern: ^\d+[smh]?$
+      default: 60s
+      x-ui-placeholder: 60s
       x-ui-toggle: true
     helm_values:
       type: object
@@ -835,12 +872,6 @@ spec:
       type: string
       title: Domain Prefix Override
       description: Override the automatically generated domain prefix
-      x-ui-toggle: true
-    disable_endpoint_validation:
-      type: boolean
-      title: Disable Endpoint Validation
-      description: Disable endpoint validation for cert-manager (uses DNS validation instead of HTTP)
-      default: false
       x-ui-toggle: true
     use_dns01:
       type: boolean
@@ -872,11 +903,14 @@ spec:
     - private
     - domain_prefix_override
     - disable_base_domain
+    - helm_release_name_override
     - domains
     - force_ssl_redirection
     - basic_auth
     - body_size
-    - disable_endpoint_validation
+    - proxy_connect_timeout
+    - proxy_read_timeout
+    - proxy_send_timeout
     - use_dns01
     - dns01_cluster_issuer
     - data_plane

--- a/modules/ingress/nginx_gateway_fabric_legacy_azure/1.0/facets.yaml
+++ b/modules/ingress/nginx_gateway_fabric_legacy_azure/1.0/facets.yaml
@@ -45,6 +45,15 @@ spec:
       title: Disable Base Domain
       description: Disable automatic creation of base domain for this gateway
       default: false
+    helm_release_name_override:
+      type: string
+      title: Helm Release Name Override
+      description: Advanced. Override the Helm release name for this gateway. Leave empty to keep the default (truncated instance/namespace name). Must be a DNS-1123 label (lowercase alphanumerics and hyphens, starting/ending with alphanumeric) and at most 34 characters. Changing this on an existing instance will recreate the release.
+      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+      maxLength: 34
+      x-ui-toggle: true
+      x-ui-placeholder: "e.g. my-gateway-stable"
+      x-ui-error-message: "Must be lowercase alphanumeric with hyphens, start/end with alphanumeric, and at most 34 characters."
     domains:
       title: Domains
       description: Map of domain key to rules
@@ -613,26 +622,30 @@ spec:
                   type: string
                   title: Mirror Service Namespace
                   description: Namespace of the mirror service
-            timeouts:
+            nginx_timeouts:
               type: object
-              title: Request Timeouts
-              description: Configure request and backend timeouts
+              title: Proxy Timeouts (per-rule override)
+              description: Override the gateway-wide proxy_{connect,read,send}_timeout for this route. Rendered via NGF SnippetsFilter at http.server.location. Leave a field empty to inherit the instance default.
               x-ui-toggle: true
               properties:
-                request:
+                proxy_connect_timeout:
                   type: string
-                  title: Request Timeout
-                  description: Total request timeout (e.g., 30s, 1m, 5m)
-                  pattern: ^\d+[smh]$
-                  default: 300s
-                  x-ui-placeholder: "300s"
-                backend_request:
+                  title: Proxy Connect Timeout
+                  description: Override proxy_connect_timeout for this route (e.g., 60s, 5m). Empty = inherit instance default.
+                  pattern: ^\d+[smh]?$
+                  x-ui-placeholder: 300s
+                proxy_read_timeout:
                   type: string
-                  title: Backend Request Timeout
-                  description: Backend response timeout (e.g., 30s, 1m, 5m)
-                  default: 300s
-                  pattern: ^\d+[smh]$
-                  x-ui-placeholder: "300s"
+                  title: Proxy Read Timeout
+                  description: Override proxy_read_timeout for this route (e.g., 60s, 5m). Empty = inherit instance default.
+                  pattern: ^\d+[smh]?$
+                  x-ui-placeholder: 300s
+                proxy_send_timeout:
+                  type: string
+                  title: Proxy Send Timeout
+                  description: Override proxy_send_timeout for this route (e.g., 60s, 5m). Empty = inherit instance default.
+                  pattern: ^\d+[smh]?$
+                  x-ui-placeholder: 300s
             cors:
               type: object
               title: CORS Configuration
@@ -794,7 +807,7 @@ spec:
             - path
             - path_type
             - method
-            - timeouts
+            - nginx_timeouts
             - cors
             - header_matches
             - query_param_matches
@@ -817,10 +830,34 @@ spec:
     body_size:
       type: string
       title: Max Body Size
-      description: Maximum allowed size of the client request body (e.g., 150m, 1g)
+      description: Maximum allowed size of the client request body (e.g., 1m, 1g)
       pattern: ^\d{1,4}(k|m|g)?$
       default: 150m
       x-ui-placeholder: 150m
+      x-ui-toggle: true
+    proxy_connect_timeout:
+      type: string
+      title: Proxy Connect Timeout
+      description: Timeout for establishing connections to upstream services (e.g., 60s, 1m). Applies gateway-wide to all routes.
+      pattern: ^\d+[smh]?$
+      default: 60s
+      x-ui-placeholder: 60s
+      x-ui-toggle: true
+    proxy_read_timeout:
+      type: string
+      title: Proxy Read Timeout
+      description: Timeout for reading responses from upstream services. Applies gateway-wide to all routes.
+      pattern: ^\d+[smh]?$
+      default: 60s
+      x-ui-placeholder: 60s
+      x-ui-toggle: true
+    proxy_send_timeout:
+      type: string
+      title: Proxy Send Timeout
+      description: Timeout for transmitting requests to upstream services. Applies gateway-wide to all routes.
+      pattern: ^\d+[smh]?$
+      default: 60s
+      x-ui-placeholder: 60s
       x-ui-toggle: true
     helm_values:
       type: object
@@ -832,12 +869,6 @@ spec:
       type: string
       title: Domain Prefix Override
       description: Override the automatically generated domain prefix
-      x-ui-toggle: true
-    disable_endpoint_validation:
-      type: boolean
-      title: Disable Endpoint Validation
-      description: Disable endpoint validation for cert-manager (uses DNS validation instead of HTTP)
-      default: false
       x-ui-toggle: true
     use_dns01:
       type: boolean
@@ -869,11 +900,14 @@ spec:
     - private
     - domain_prefix_override
     - disable_base_domain
+    - helm_release_name_override
     - domains
     - force_ssl_redirection
     - basic_auth
     - body_size
-    - disable_endpoint_validation
+    - proxy_connect_timeout
+    - proxy_read_timeout
+    - proxy_send_timeout
     - use_dns01
     - dns01_cluster_issuer
     - data_plane

--- a/modules/ingress/nginx_gateway_fabric_legacy_azure/1.0/facets.yaml
+++ b/modules/ingress/nginx_gateway_fabric_legacy_azure/1.0/facets.yaml
@@ -840,24 +840,24 @@ spec:
       title: Proxy Connect Timeout
       description: Timeout for establishing connections to upstream services (e.g., 60s, 1m). Applies gateway-wide to all routes.
       pattern: ^\d+[smh]?$
-      default: 60s
-      x-ui-placeholder: 60s
+      default: 300s
+      x-ui-placeholder: 300s
       x-ui-toggle: true
     proxy_read_timeout:
       type: string
       title: Proxy Read Timeout
       description: Timeout for reading responses from upstream services. Applies gateway-wide to all routes.
       pattern: ^\d+[smh]?$
-      default: 60s
-      x-ui-placeholder: 60s
+      default: 300s
+      x-ui-placeholder: 300s
       x-ui-toggle: true
     proxy_send_timeout:
       type: string
       title: Proxy Send Timeout
       description: Timeout for transmitting requests to upstream services. Applies gateway-wide to all routes.
       pattern: ^\d+[smh]?$
-      default: 60s
-      x-ui-placeholder: 60s
+      default: 300s
+      x-ui-placeholder: 300s
       x-ui-toggle: true
     helm_values:
       type: object

--- a/modules/ingress/nginx_gateway_fabric_legacy_gcp/1.0/facets.yaml
+++ b/modules/ingress/nginx_gateway_fabric_legacy_gcp/1.0/facets.yaml
@@ -45,6 +45,15 @@ spec:
       title: Disable Base Domain
       description: Disable automatic creation of base domain for this gateway
       default: false
+    helm_release_name_override:
+      type: string
+      title: Helm Release Name Override
+      description: Advanced. Override the Helm release name for this gateway. Leave empty to keep the default (truncated instance/namespace name). Must be a DNS-1123 label (lowercase alphanumerics and hyphens, starting/ending with alphanumeric) and at most 34 characters. Changing this on an existing instance will recreate the release.
+      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+      maxLength: 34
+      x-ui-toggle: true
+      x-ui-placeholder: "e.g. my-gateway-stable"
+      x-ui-error-message: "Must be lowercase alphanumeric with hyphens, start/end with alphanumeric, and at most 34 characters."
     domains:
       title: Domains
       description: Map of domain key to rules
@@ -613,26 +622,30 @@ spec:
                   type: string
                   title: Mirror Service Namespace
                   description: Namespace of the mirror service
-            timeouts:
+            nginx_timeouts:
               type: object
-              title: Request Timeouts
-              description: Configure request and backend timeouts
+              title: Proxy Timeouts (per-rule override)
+              description: Override the gateway-wide proxy_{connect,read,send}_timeout for this route. Rendered via NGF SnippetsFilter at http.server.location. Leave a field empty to inherit the instance default.
               x-ui-toggle: true
               properties:
-                request:
+                proxy_connect_timeout:
                   type: string
-                  title: Request Timeout
-                  description: Total request timeout (e.g., 30s, 1m, 5m)
-                  pattern: ^\d+[smh]$
-                  default: 300s
-                  x-ui-placeholder: "300s"
-                backend_request:
+                  title: Proxy Connect Timeout
+                  description: Override proxy_connect_timeout for this route (e.g., 60s, 5m). Empty = inherit instance default.
+                  pattern: ^\d+[smh]?$
+                  x-ui-placeholder: 300s
+                proxy_read_timeout:
                   type: string
-                  title: Backend Request Timeout
-                  description: Backend response timeout (e.g., 30s, 1m, 5m)
-                  default: 300s
-                  pattern: ^\d+[smh]$
-                  x-ui-placeholder: "300s"
+                  title: Proxy Read Timeout
+                  description: Override proxy_read_timeout for this route (e.g., 60s, 5m). Empty = inherit instance default.
+                  pattern: ^\d+[smh]?$
+                  x-ui-placeholder: 300s
+                proxy_send_timeout:
+                  type: string
+                  title: Proxy Send Timeout
+                  description: Override proxy_send_timeout for this route (e.g., 60s, 5m). Empty = inherit instance default.
+                  pattern: ^\d+[smh]?$
+                  x-ui-placeholder: 300s
             cors:
               type: object
               title: CORS Configuration
@@ -794,7 +807,7 @@ spec:
             - path
             - path_type
             - method
-            - timeouts
+            - nginx_timeouts
             - cors
             - header_matches
             - query_param_matches
@@ -817,10 +830,34 @@ spec:
     body_size:
       type: string
       title: Max Body Size
-      description: Maximum allowed size of the client request body (e.g., 150m, 1g)
+      description: Maximum allowed size of the client request body (e.g., 1m, 1g)
       pattern: ^\d{1,4}(k|m|g)?$
       default: 150m
       x-ui-placeholder: 150m
+      x-ui-toggle: true
+    proxy_connect_timeout:
+      type: string
+      title: Proxy Connect Timeout
+      description: Timeout for establishing connections to upstream services (e.g., 60s, 1m). Applies gateway-wide to all routes.
+      pattern: ^\d+[smh]?$
+      default: 60s
+      x-ui-placeholder: 60s
+      x-ui-toggle: true
+    proxy_read_timeout:
+      type: string
+      title: Proxy Read Timeout
+      description: Timeout for reading responses from upstream services. Applies gateway-wide to all routes.
+      pattern: ^\d+[smh]?$
+      default: 60s
+      x-ui-placeholder: 60s
+      x-ui-toggle: true
+    proxy_send_timeout:
+      type: string
+      title: Proxy Send Timeout
+      description: Timeout for transmitting requests to upstream services. Applies gateway-wide to all routes.
+      pattern: ^\d+[smh]?$
+      default: 60s
+      x-ui-placeholder: 60s
       x-ui-toggle: true
     helm_values:
       type: object
@@ -832,12 +869,6 @@ spec:
       type: string
       title: Domain Prefix Override
       description: Override the automatically generated domain prefix
-      x-ui-toggle: true
-    disable_endpoint_validation:
-      type: boolean
-      title: Disable Endpoint Validation
-      description: Disable endpoint validation for cert-manager (uses DNS validation instead of HTTP)
-      default: false
       x-ui-toggle: true
     use_dns01:
       type: boolean
@@ -869,11 +900,14 @@ spec:
     - private
     - domain_prefix_override
     - disable_base_domain
+    - helm_release_name_override
     - domains
     - force_ssl_redirection
     - basic_auth
     - body_size
-    - disable_endpoint_validation
+    - proxy_connect_timeout
+    - proxy_read_timeout
+    - proxy_send_timeout
     - use_dns01
     - dns01_cluster_issuer
     - data_plane

--- a/modules/ingress/nginx_gateway_fabric_legacy_gcp/1.0/facets.yaml
+++ b/modules/ingress/nginx_gateway_fabric_legacy_gcp/1.0/facets.yaml
@@ -840,24 +840,24 @@ spec:
       title: Proxy Connect Timeout
       description: Timeout for establishing connections to upstream services (e.g., 60s, 1m). Applies gateway-wide to all routes.
       pattern: ^\d+[smh]?$
-      default: 60s
-      x-ui-placeholder: 60s
+      default: 300s
+      x-ui-placeholder: 300s
       x-ui-toggle: true
     proxy_read_timeout:
       type: string
       title: Proxy Read Timeout
       description: Timeout for reading responses from upstream services. Applies gateway-wide to all routes.
       pattern: ^\d+[smh]?$
-      default: 60s
-      x-ui-placeholder: 60s
+      default: 300s
+      x-ui-placeholder: 300s
       x-ui-toggle: true
     proxy_send_timeout:
       type: string
       title: Proxy Send Timeout
       description: Timeout for transmitting requests to upstream services. Applies gateway-wide to all routes.
       pattern: ^\d+[smh]?$
-      default: 60s
-      x-ui-placeholder: 60s
+      default: 300s
+      x-ui-placeholder: 300s
       x-ui-toggle: true
     helm_values:
       type: object


### PR DESCRIPTION
* feat(ingress): expose helm_release_name_override on legacy nginx_gateway_fabric

Add a `helm_release_name_override` advanced spec field to the legacy AWS,
Azure, and GCP nginx_gateway_fabric modules so users can pin a stable
Helm release name. The utility module reads this field directly from
var.instance.spec; no main.tf passthrough needed.

Empty/unset preserves the existing truncated-name behavior, so existing
deployments see no state diff.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

* feat(ingress): validate helm_release_name_override input in form

Add JSON-schema pattern (DNS-1123 label) and maxLength: 34 on the
helm_release_name_override field across legacy AWS/Azure/GCP modules.
Includes x-ui-error-message and placeholder so the UI surfaces a clear
error before submit. Pairs with the TF-side validation in
facets-utility-modules#36.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

* feat(ingress): expose proxy timeout overrides on legacy fabric flavors

Add proxy_{connect,read,send}_timeout (default 60s) at the instance level and
per-rule nginx_timeouts overrides on all three nginx_gateway_fabric_legacy_*
flavors (aws, azure, gcp). Lower body_size default from 150m to 1m to match
the utility module change.

Required for workloads migrating off legacy nginx_ingress_controller, which
exposed these as per-ingress annotations.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

* feat(ingress/tools_migration): add convert_nginx_ingress script + MIGRATION.md

Tooling for converting a legacy `nginx_ingress_controller` blueprint JSON into
the production `nginx_gateway_fabric_legacy_{aws,gcp,azure}/1.0` shape. Built
around the saas-cp/tools rollout.

Key behaviors:
- `--cloud` flag picks the wrapper flavor; output always emits version "1.0".
- Drops the entire `advanced` block (old nginx-ingress Helm overrides don't
  port cleanly to NGF's chart) with a warning listing what was lost.
- Always injects legacy-parity defaults the new module does not default to:
  `body_size: 150m`, `proxy_{connect,read,send}_timeout: 300s`.
- Hardcodes `helm_release_name_override: "tools-facets"` for this rollout.
- For rules whose service name contains "grafana", auto-emits
  `request_header_modifier.remove.Authorization` so Grafana's anonymous mode
  isn't shadowed by the basic-auth header from the gateway.
- Drops `nginx.ingress.kubernetes.io/backend-protocol: HTTPS` annotations from
  any rule that carries them and prints a loud per-rule warning — Gateway API
  has no `proxy_ssl_verify off` equivalent, so the operator must either expose
  plain HTTP on the backend or set up a BackendTLSPolicy. MIGRATION.md walks
  through the three options.

Lives at modules/ingress/tools_migration/ rather than inside any flavor's
versioned directory so it's not packaged into the IaC modules.

* docs(ingress/tools_migration): expand k8s-dashboard-new Kong-fix instructions

Calls out the specific helm-values change (`kong.proxy.http.enabled: true`)
that flips the bundled Kong proxy from TLS-only to TLS+HTTP, plus the
corresponding port flip in the converted blueprint. This is the concrete
fix the saas-cp/tools rollout actually used; the previous wording was
generic.

* fix(ingress): align legacy nginx_gateway_fabric wrappers with utility module

- Add helm_release_name_override to top-level x-ui-order (was defined but
  unordered, so hidden/misplaced in the form) — addresses review blocker.
- Drop per-rule timeouts and nginx_timeouts schema fields: HTTPRoute
  timeouts are ignored by NGF (#2164) and nginx_timeouts had no render path.
  Gateway-wide proxy_*_timeout covers the supported case.
- body_size default 1m -> 150m to match utility default, avoid silent 413.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

* chore(ingress): remove tools_migration tooling from wrapper PR

Out of scope for the wrapper modules per review (sanmesh #4). convert_nginx_ingress.py
+ MIGRATION.md moved to a standalone location; will land separately if needed.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

* feat(ingress): re-add per-rule nginx_timeouts to legacy wrappers

Per-rule proxy_{connect,read,send}_timeout, now backed by a real SnippetsFilter
rendering path in the utility module (capillary parity). Dead Gateway-API
rules[].timeouts stays removed.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

* chore(ingress): remove dead disable_endpoint_validation field

Declared in the legacy wrapper schemas but consumed nowhere (0 refs in wrapper or
utility main.tf) — a no-op UI toggle. Removed from aws/azure/gcp.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

* fix(ingress): accept unit-less seconds for proxy timeouts

Relax pattern ^\d+[smh]$ -> ^\d+[smh]?$ on instance + per-rule proxy timeout
fields. nginx treats a bare number as seconds (e.g. '120' = 120s), so the unit
requirement rejected valid input. Still blocks non-numeric garbage.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

---------

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
Co-authored-by: Shashwat Pathak <shashwat.pathak@facets.cloud>
(cherry picked from commit 366c39b48d5ecf0e223b0df4647e866c4dc27a42)

# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Related issues
<!-- If this PR is related to an existing issue or feature request, please reference clickup task url here. -->

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist
<!-- Please delete options that are not relevant. -->

- [ ] I have created feat/bugfix branch out of `develop` branch
- [ ] Code passes linting/formatting checks
- [ ] Changes to resources have been tested in our dev environments
- [ ] I have made corresponding changes to the documentation

## Testing

<!-- Detail how the changes have been tested, including any automated or manual tests performed. Include the results of the testing (Screenshots, links to releases, etc.), including any issues or bugs encountered and how they were resolved -->

## Reviewer instructions
<!-- Include any instructions or guidance for reviewers, including specific areas to focus on or areas that require additional attention -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a gateway-level option to override the Helm release name for deployments.
  * Added gateway-wide proxy timeout controls (connect, read, and send).
  * Updated per-route timeout configuration to use NGINX proxy timeout overrides.

* **Removed**
  * Removed the deprecated endpoint validation setting from gateway configuration.

* **Notes**
  * Timeout fields and UI ordering/labels were updated to match the new NGINX-focused configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->