### PR TITLE
chore(gateway_api_crd): default Gateway API CRDs to v1.5.1

### DIFF
--- a/modules/gateway_api_crd/k8s/1.0/facets.yaml
+++ b/modules/gateway_api_crd/k8s/1.0/facets.yaml
@@ -33,9 +33,11 @@ spec:
         - experimental
     version:
       type: string
-      default: v1.4.1
+      default: v1.5.1
       description: Gateway API version to install
       enum:
+        - v1.5.1
+        - v1.5.0
         - v1.4.1
         - v1.4.0
         - v1.3.0
@@ -47,4 +49,4 @@ sample:
   disabled: true
   spec:
     channel: experimental
-    version: v1.4.1
+    version: v1.5.1

--- a/modules/gateway_api_crd/k8s/1.0/main.tf
+++ b/modules/gateway_api_crd/k8s/1.0/main.tf
@@ -1,7 +1,7 @@
 locals {
   name      = lower(var.environment.namespace == "default" ? var.instance_name : "${var.environment.namespace}-${var.instance_name}")
   namespace = var.environment.namespace
-  version   = lookup(var.instance.spec, "version", "v1.4.1")
+  version   = lookup(var.instance.spec, "version", "v1.5.1")
   channel   = lookup(var.instance.spec, "channel", "experimental")
 
   # Build the install URL based on version and channel


### PR DESCRIPTION
## Why

NGINX Gateway Fabric 2.5.0+ requires Gateway API v1.5.x. This is the prerequisite CRD bump for the companion NGF 2.6.3 upgrade (separate PR in `facets-utility-modules`).

## Scope

- Default `version` `v1.4.1` → `v1.5.1`; enum extended (`v1.5.1`, `v1.5.0` added; existing `v1.4.x`/`v1.3.0`/`v1.2.0` retained).
- Channel stays `experimental`; install still uses `kubectl apply --server-side`.
- v1.5.1 over v1.5.0 = conformance/docs patch, zero CRD schema change.

CRDs are not vendored — only the version/channel strings change. The asset filenames are identical at v1.5.1, so the install URL shape is unchanged.

## Breaking changes v1.4.1 → v1.5.1 and handling

| Change | Detail | Impact / handling |
|---|---|---|
| ReferenceGrant `v1` added | `v1beta1` still **served + storage**; `v1` added alongside | Safe/additive — existing v1beta1 CRs valid, no migration |
| TLSRoute promoted to `v1` (standard); experimental storage v1alpha3→v1 | alpha versions still served (experimental) | Only affects TLSRoute users — none here; pre-check `kubectl get tlsroutes -A` |
| `XListenerSet` → `ListenerSet` (v1) | old `xlistenersets` kind **removed** | Only affects XListenerSet users — none here; pre-check `kubectl get xlistenersets -A` |
| Gateway/GatewayClass/HTTPRoute/GRPCRoute | schemas grew (CORS, cert selection, client-cert) | All additive optional fields on the `v1` storage schema — existing CRs not rejected |
| New `safe-upgrades` ValidatingAdmissionPolicy | blocks downgrade below 1.5.0 + standard↔experimental mixing | Forward upgrade unaffected; **rollback below 1.5.0 requires deleting this VAP + binding first** — note in runbook |
| Min Kubernetes | v1.5.x wants K8s ≥1.31 (TLSRoute CEL) | Satisfied — cluster nodes ≥1.31.3, CP 1.33 |

## Apply ordering

Gateway API CRDs (this module) must be applied **before** the NGF controller upgrade.

## Pre-flight

`kubectl get tlsroutes,xlistenersets -A` should be empty before upgrade (the only kinds with served-version loss / rename).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
## Pre-flight & operational caveats (verified against the real v1.5.1/v1.4.1 manifests)

Confirmed by downloading + diffing the actual install bundles:
- **Served-version-loss scan across all 11 shared CRDs: none dropped**, except the whole `xlistenersets` CRD (renamed → `listenersets`, kind `XListenerSet`→`ListenerSet`, group `x-k8s.io`→`k8s.io`). Not an in-place migration.
- **ReferenceGrant** `v1beta1` stays **served + storage** (`v1` added alongside) → existing CRs valid, zero migration.
- **TLSRoute** storage moves `v1alpha3 → v1` (alpha still served).
- **`safe-upgrades` ValidatingAdmissionPolicy** ships in v1.5.1 (`failurePolicy: Fail`, action `Deny`): blocks experimental-on-standard and **any rollback to ≤ v1.4.x** until you `kubectl delete validatingadmissionpolicy safe-upgrades.gateway.networking.k8s.io` + its binding.
- **`--server-side` is mandatory** — the `httproutes` CRD alone is ~533 KB, past the 262 KB client-side annotation limit. Keep it.

Run before applying:
```
kubectl get tlsroutes,xlistenersets -A          # expect empty
kubectl get crd httproutes.gateway.networking.k8s.io \
  -o jsonpath='{range .metadata.managedFields[*]}{.manager}{"\n"}{end}'
```
If managedFields show `kubectl-client-side-apply` (or a conflicting non-kubectl manager), the install Job's `kubectl apply --server-side` (`main.tf:100`, no `--force-conflicts`, `backoff_limit=3`) errors on conflict → add `--force-conflicts`.

Apply these CRDs **before** the NGF 2.6.3 controller upgrade (companion PR `Facets-cloud/facets-utility-modules#39`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * The default Gateway API Custom Resource Definition (CRD) has been upgraded from version v1.4.1 to v1.5.1. All new Gateway API installations now target this latest stable release by default, providing updated API specifications and enhanced compatibility features. Earlier versions remain available for backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->