### PR TITLE
feat(artifactories): label dockerhub registry secret with secret-copier=yes

### DIFF
--- a/modules/artifactories/default/0.1/registry_secret.tf
+++ b/modules/artifactories/default/0.1/registry_secret.tf
@@ -3,7 +3,7 @@ resource "kubernetes_secret_v1" "registry_secret" {
   metadata {
     name      = each.value.name
     namespace = local.namespace
-    labels    = lookup(local.metadata, "labels", {})
+    labels    = merge(lookup(local.metadata, "labels", {}), { "secret-copier" = "yes" })
   }
   data = {
     ".dockerconfigjson" : each.value.dockerconfigjson


### PR DESCRIPTION
## What
Adds the `secret-copier=yes` label to the DockerHub `dockerconfigjson` secret created by `artifactories/default/0.1`.

```diff
-    labels    = lookup(local.metadata, "labels", {})
+    labels    = merge(lookup(local.metadata, "labels", {}), { "secret-copier" = "yes" })
```

## Why
On containerd 2.x nodes (k8s 1.34+/1.35), node-level `/etc/containerd/config.toml` DockerHub login is silently ignored, so private DockerHub pulls fail. The fix is the k8s imagePullSecret path:

1. **artifactories** creates + **labels** the dockerconfigjson secret (this PR)
2. **secret-copier** (shell-operator, watches `secret-copier=yes` in `default`) replicates it to every namespace — real-time on new-namespace + secret change, plus a daily reconcile
3. **image-pull-secret-injector** (mutating webhook, all namespaces) injects the reference into every pod

Pod-level injection = SA-agnostic; no service-account patching needed. This is the same label the redesigned `artifactories/standard/1.0` module already sets.

## Scope
- Only the DockerHub secret resource (`for_each = local.artifactories_dockerhub`) — ECR path untouched.
- Requires the secret to reside in the `default` namespace (secret-copier's source) and `secret-copier` + `image_pull_secret_injector` to be deployed in the cluster.

## Test plan
- [ ] Dev 1.35/containerd-2.x env: labeled secret in `default` → confirm secret-copier replicates it to a fresh namespace
- [ ] New pod using a private DockerHub image gets `imagePullSecrets` injected and pulls successfully
- [ ] Existing (non-DockerHub / ECR) behavior unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Generated registry secrets now include an additional label alongside existing metadata labels, improving consistency and making them easier to identify and manage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->