### PR TITLE
chore(ci): point module_register at facets-scripts

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -97,7 +97,7 @@ jobs:
             for dir in "${dirs[@]}"; do
               if [[ -f "$dir/facets.yaml" ]] && ls $dir/*.tf &> /dev/null; then
                 # Register the module as preview
-                curl -s https://facets-cloud.github.io/facets-schemas/scripts/module_register.sh | bash -s -- -c "$URL" -u "$USERNAME" -t "$TOKEN" -p "$dir" -r "${GITHUB_REF}"
+                curl -s https://facets-cloud.github.io/facets-scripts/scripts/module_register.sh | bash -s -- -c "$URL" -u "$USERNAME" -t "$TOKEN" -p "$dir" -r "${GITHUB_REF}"
               else
                 echo "No facets.yaml found in $dir"
               fi


### PR DESCRIPTION
## What
Update the `module_register.sh` URL in the preview workflow from `facets-schemas/scripts` → `facets-scripts/scripts`.

## Why
`facets-schemas` is being retired (secret leaked in its git history). Its `scripts/` folder — the only live, hand-maintained content — moved to the new public **[facets-scripts](https://github.com/Facets-cloud/facets-scripts)** repo, served via GitHub Pages at `https://facets-cloud.github.io/facets-scripts/scripts/`. No behavior change; same scripts, new host path.

Part of a coordinated cross-repo migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the preview deployment process to use the correct script source, helping module registration run reliably during previews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->