### PR TITLE
artifactories: pin ecr-token-refresher image to facetscloud/aws-kubectl:1.7.0

### DIFF
--- a/modules/artifactories/default/0.1/ecr-token-refresher.tf
+++ b/modules/artifactories/default/0.1/ecr-token-refresher.tf
@@ -46,7 +46,7 @@ resource "kubernetes_cron_job_v1" "ecr-token-refresher-cron" {
             }
             container {
               name              = "kubectl"
-              image             = "facetscloud/aws-kubectl:1.31.0"
+              image             = "facetscloud/aws-kubectl:1.7.0"
               image_pull_policy = "Always"
               command           = ["/bin/sh", "-c", file("${path.module}/ecr-token-refresher-command")]
               env {


### PR DESCRIPTION
Pins the artifactories ecr-token-refresher cronjob image to **`facetscloud/aws-kubectl:1.7.0`** (matches the original xynova/aws-kubectl gist, kubectl v1.7.0). Follow-up to #559 (which set it to :1.31.0).

File: `modules/artifactories/default/0.1/ecr-token-refresher.tf`.

Note: kubectl v1.7.0 is a 2017 binary; validate on a real amd64 node before rollout (a local panic seen under QEMU arm64-emulation is likely an emulation artifact, not a node failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)