### PR TITLE
artifactories: pin ecr-token-refresher image to facetscloud/aws-kubectl:1.7.0

### DIFF
--- a/modules/artifactories/default/0.1/ecr-token-refresher.tf
+++ b/modules/artifactories/default/0.1/ecr-token-refresher.tf
@@ -46,7 +46,7 @@ resource "kubernetes_cron_job_v1" "ecr-token-refresher-cron" {
             }
             container {
               name              = "kubectl"
-              image             = "facetscloud/aws-kubectl:1.31.0"
+              image             = "facetscloud/aws-kubectl:1.7.0"
               image_pull_policy = "Always"
               command           = ["/bin/sh", "-c", file("${path.module}/ecr-token-refresher-command")]
               env {


### PR DESCRIPTION
Promotes to `master` the ecr-token-refresher image pin merged to `develop` in #561 (cherry-pick of squash commit b517d9af).

Sets the artifactories ecr-token-refresher cronjob image to **`facetscloud/aws-kubectl:1.7.0`** (`modules/artifactories/default/0.1/ecr-token-refresher.tf`).

Note: `:1.7.0` is amd64-only (cronjob pods pinned to `kubernetes.io/arch=amd64`); kubectl v1.7.0 is a 2017 binary — validate on a real amd64 node before rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the container image used by a scheduled background task to a different version for improved compatibility and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->