### PR TITLE
feat(aws_eks): expose facets_dedicated min_nodes in spec

### DIFF
--- a/modules/kubernetes_cluster/aws_eks/0.1/facets.yaml
+++ b/modules/kubernetes_cluster/aws_eks/0.1/facets.yaml
@@ -204,6 +204,31 @@ spec:
                 field: spec.nodepools.facets_dedicated.enable
                 values: [true]
               x-ui-overrides-only: true
+            min_nodes:
+              title: Min Nodes
+              description: Minimum number of worker nodes in the node pool. Set to
+                2 or more for high availability of the platform components pinned to
+                this node pool.
+              type: integer
+              minimum: 1
+              maximum: 200
+              default: 1
+              x-ui-visible-if:
+                field: spec.nodepools.facets_dedicated.enable
+                values: [true]
+              x-ui-overrides-only: true
+            desired_nodes:
+              title: Desired Nodes
+              description: Desired number of worker nodes. Falls back to Min Nodes
+                when unset. Applied only at node pool creation (ignored on later
+                updates). Must be between Min Nodes and Max Nodes.
+              type: integer
+              minimum: 1
+              maximum: 200
+              x-ui-visible-if:
+                field: spec.nodepools.facets_dedicated.enable
+                values: [true]
+              x-ui-overrides-only: true
             instance_type:
               title: Instance Type
               description: Instance Type of Facets Dedicated Node Pool
@@ -243,7 +268,7 @@ spec:
                 values: [true]
           required: ["instance_type"]
           x-ui-order: [enable, instance_type, node_lifecycle_type, root_disk_volume,
-            max_nodes, ami_id, ami_name_filter, ami_owner_id]
+            max_nodes, min_nodes, desired_nodes, ami_id, ami_name_filter, ami_owner_id]
         ondemand_fallback:
           title: Ondemand Fallback Nodepool Spec
           description: Specifications of Ondemand Fallback Nodepool

--- a/modules/kubernetes_cluster/aws_eks/0.2/facets.yaml
+++ b/modules/kubernetes_cluster/aws_eks/0.2/facets.yaml
@@ -218,6 +218,18 @@ spec:
                 field: spec.nodepools.facets_dedicated.enable
                 values: [true]
               x-ui-overrides-only: true
+            desired_nodes:
+              title: Desired Nodes
+              description: Desired number of worker nodes. Falls back to Min Nodes
+                when unset. Applied only at node pool creation (ignored on later
+                updates), and bounded to [Min Nodes, Max Nodes].
+              type: integer
+              minimum: 1
+              maximum: 200
+              x-ui-visible-if:
+                field: spec.nodepools.facets_dedicated.enable
+                values: [true]
+              x-ui-overrides-only: true
             instance_type:
               title: Instance Type
               description: Instance type for Facets Dedicated Node Pool
@@ -256,7 +268,7 @@ spec:
                 values: [true]
           required: ["instance_type"]
           x-ui-order: [enable, instance_type, node_lifecycle_type, root_disk_volume,
-            max_nodes, min_nodes, ami_id, ami_name_filter, ami_owner_id]
+            max_nodes, min_nodes, desired_nodes, ami_id, ami_name_filter, ami_owner_id]
         ondemand_fallback:
           title: Ondemand Fallback Nodepool Spec
           description: Specifications of Ondemand Fallback Nodepool

--- a/modules/kubernetes_cluster/aws_eks/0.2/facets.yaml
+++ b/modules/kubernetes_cluster/aws_eks/0.2/facets.yaml
@@ -205,6 +205,19 @@ spec:
                 field: spec.nodepools.facets_dedicated.enable
                 values: [true]
               x-ui-overrides-only: true
+            min_nodes:
+              title: Min Nodes
+              description: Minimum number of worker nodes in the node pool. Set to
+                2 or more for high availability of the platform components pinned to
+                this node pool.
+              type: integer
+              minimum: 1
+              maximum: 200
+              default: 1
+              x-ui-visible-if:
+                field: spec.nodepools.facets_dedicated.enable
+                values: [true]
+              x-ui-overrides-only: true
             instance_type:
               title: Instance Type
               description: Instance type for Facets Dedicated Node Pool
@@ -243,7 +256,7 @@ spec:
                 values: [true]
           required: ["instance_type"]
           x-ui-order: [enable, instance_type, node_lifecycle_type, root_disk_volume,
-            max_nodes, ami_id, ami_name_filter, ami_owner_id]
+            max_nodes, min_nodes, ami_id, ami_name_filter, ami_owner_id]
         ondemand_fallback:
           title: Ondemand Fallback Nodepool Spec
           description: Specifications of Ondemand Fallback Nodepool

--- a/modules/kubernetes_cluster/aws_eks/0.2/facets.yaml
+++ b/modules/kubernetes_cluster/aws_eks/0.2/facets.yaml
@@ -222,7 +222,7 @@ spec:
               title: Desired Nodes
               description: Desired number of worker nodes. Falls back to Min Nodes
                 when unset. Applied only at node pool creation (ignored on later
-                updates), and bounded to [Min Nodes, Max Nodes].
+                updates). Must be between Min Nodes and Max Nodes.
               type: integer
               minimum: 1
               maximum: 200


### PR DESCRIPTION
## What
Adds a `min_nodes` field to the `facets_dedicated` nodepool spec in `kubernetes_cluster/aws_eks/0.2` (default `1`).

## Why
The dedicated managed node group hosts Karpenter and the platform/monitoring singletons. Its `min_size`/`desired_size` were hardcoded to 1, making a single dedicated node a SPOF. Exposing `min_nodes` lets clusters run the dedicated node group with ≥2 nodes (across AZs) for HA.

## Pairs with
`facets-cloud/facets-iac` PR #2134, which threads `spec.nodepools.facets_dedicated.min_nodes` into the managed node group's `min_size`/`desired_size` (defaulting to 1, backward compatible).

## Compatibility
`default: 1` — no behaviour change for existing clusters. Set `min_nodes: 2` for HA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable minimum node count for dedicated EKS node pools.
  * Added a configurable desired node count for dedicated node pools, applied at creation time.
  * Both settings are shown in the interface only when dedicated node pools are enabled.
  * Updated the configuration field ordering to improve readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->