### PR TITLE
sync: expose facets_dedicated min_nodes/desired_nodes in aws_eks spec (0.1 + 0.2)

### DIFF
--- a/modules/kubernetes_cluster/aws_eks/0.1/facets.yaml
+++ b/modules/kubernetes_cluster/aws_eks/0.1/facets.yaml
@@ -204,6 +204,31 @@ spec:
                 field: spec.nodepools.facets_dedicated.enable
                 values: [true]
               x-ui-overrides-only: true
+            min_nodes:
+              title: Min Nodes
+              description: Minimum number of worker nodes in the node pool. Set to
+                2 or more for high availability of the platform components pinned to
+                this node pool.
+              type: integer
+              minimum: 1
+              maximum: 200
+              default: 1
+              x-ui-visible-if:
+                field: spec.nodepools.facets_dedicated.enable
+                values: [true]
+              x-ui-overrides-only: true
+            desired_nodes:
+              title: Desired Nodes
+              description: Desired number of worker nodes. Falls back to Min Nodes
+                when unset. Applied only at node pool creation (ignored on later
+                updates). Must be between Min Nodes and Max Nodes.
+              type: integer
+              minimum: 1
+              maximum: 200
+              x-ui-visible-if:
+                field: spec.nodepools.facets_dedicated.enable
+                values: [true]
+              x-ui-overrides-only: true
             instance_type:
               title: Instance Type
               description: Instance Type of Facets Dedicated Node Pool
@@ -243,7 +268,7 @@ spec:
                 values: [true]
           required: ["instance_type"]
           x-ui-order: [enable, instance_type, node_lifecycle_type, root_disk_volume,
-            max_nodes, ami_id, ami_name_filter, ami_owner_id]
+            max_nodes, min_nodes, desired_nodes, ami_id, ami_name_filter, ami_owner_id]
         ondemand_fallback:
           title: Ondemand Fallback Nodepool Spec
           description: Specifications of Ondemand Fallback Nodepool

--- a/modules/kubernetes_cluster/aws_eks/0.2/facets.yaml
+++ b/modules/kubernetes_cluster/aws_eks/0.2/facets.yaml
@@ -205,6 +205,31 @@ spec:
                 field: spec.nodepools.facets_dedicated.enable
                 values: [true]
               x-ui-overrides-only: true
+            min_nodes:
+              title: Min Nodes
+              description: Minimum number of worker nodes in the node pool. Set to
+                2 or more for high availability of the platform components pinned to
+                this node pool.
+              type: integer
+              minimum: 1
+              maximum: 200
+              default: 1
+              x-ui-visible-if:
+                field: spec.nodepools.facets_dedicated.enable
+                values: [true]
+              x-ui-overrides-only: true
+            desired_nodes:
+              title: Desired Nodes
+              description: Desired number of worker nodes. Falls back to Min Nodes
+                when unset. Applied only at node pool creation (ignored on later
+                updates). Must be between Min Nodes and Max Nodes.
+              type: integer
+              minimum: 1
+              maximum: 200
+              x-ui-visible-if:
+                field: spec.nodepools.facets_dedicated.enable
+                values: [true]
+              x-ui-overrides-only: true
             instance_type:
               title: Instance Type
               description: Instance type for Facets Dedicated Node Pool
@@ -243,7 +268,7 @@ spec:
                 values: [true]
           required: ["instance_type"]
           x-ui-order: [enable, instance_type, node_lifecycle_type, root_disk_volume,
-            max_nodes, ami_id, ami_name_filter, ami_owner_id]
+            max_nodes, min_nodes, desired_nodes, ami_id, ami_name_filter, ami_owner_id]
         ondemand_fallback:
           title: Ondemand Fallback Nodepool Spec
           description: Specifications of Ondemand Fallback Nodepool


### PR DESCRIPTION
## What
Sync of #563 (merged to `develop`) into `master`. Cherry-pick of the same change — adds `min_nodes` and `desired_nodes` to the `facets_dedicated` nodepool spec in `kubernetes_cluster/aws_eks` **0.1 and 0.2**.

## Details
- `min_nodes` (integer, 1–200, default 1) and `desired_nodes` (integer, 1–200, optional → falls back to Min) added to the form, with `x-ui-order` updated.
- Backward compatible: unset → `min=1`, `desired→min` (same as before).
- Pairs with facets-iac (terraform) which consumes these via `spec.nodepools.facets_dedicated.{min_nodes,desired_nodes}`.

Cherry-picked from develop merge `c7487b84`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable minimum and desired node counts for dedicated EKS node pools.
  * Added validation limits and UI visibility controls for the new settings.
  * Updated the configuration interface ordering to include the node count options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->