### PR TITLE
fix(kube-rbac-proxy): force quay image on operator helm releases

### DIFF
--- a/modules/database_operator/default/0.1/main.tf
+++ b/modules/database_operator/default/0.1/main.tf
@@ -32,6 +32,20 @@ VALUES
     yamlencode({
       imagePullSecrets = var.inputs.kubernetes_details.attributes.legacy_outputs.registry_secret_objects
     }),
+    # kube-rbac-proxy: gcr.io/kubebuilder is sunset (kubebuilder discussions/3907).
+    # Inject quay.io via values (provider-version-agnostic; same convention as the
+    # blocks above). Placed before user values so an explicit user override still wins;
+    # still overrides the chart's gcr default regardless of the pinned chart version.
+    yamlencode({
+      controllerManager = {
+        kubeRbacProxy = {
+          image = {
+            repository = "quay.io/brancz/kube-rbac-proxy"
+            tag        = "v0.13.1"
+          }
+        }
+      }
+    }),
     yamlencode(local.user_supplied_helm_values)
   ]
 }

--- a/modules/mongodb_auth_operator/default/0.1/main.tf
+++ b/modules/mongodb_auth_operator/default/0.1/main.tf
@@ -30,6 +30,20 @@ VALUES
     yamlencode({
       imagePullSecrets = var.inputs.kubernetes_details.attributes.legacy_outputs.registry_secret_objects
     }),
+    # kube-rbac-proxy: gcr.io/kubebuilder is sunset (kubebuilder discussions/3907).
+    # Inject quay.io via values (provider-version-agnostic; same convention as the
+    # blocks above). Placed before user values so an explicit user override still wins;
+    # still overrides the chart's gcr default regardless of the pinned chart version.
+    yamlencode({
+      controllerManager = {
+        kubeRbacProxy = {
+          image = {
+            repository = "quay.io/brancz/kube-rbac-proxy"
+            tag        = "v0.13.1"
+          }
+        }
+      }
+    }),
     yamlencode(local.user_supplied_helm_values)
   ]
 }


### PR DESCRIPTION
## Why
`gcr.io/kubebuilder/kube-rbac-proxy` is deprecated. GCR images are unavailable from **2025-03-18** ([kubebuilder#3907](https://github.com/kubernetes-sigs/kubebuilder/discussions/3907)); affected pods hit `ImagePullBackOff`. Reported in #customer-issues.

## What
Override the proxy image → `quay.io/brancz/kube-rbac-proxy:v0.13.1` on the operator `helm_release` resources, injected via the `values` list (`yamlencode`), **not** a `set{}` block:
- Same convention already used in these callers.
- **Agnostic to the helm provider `set` syntax** (block in 2.x → list attribute in 3.x).
- Placed **before** `user_supplied_helm_values`, so a user override still wins, while overriding the chart's gcr default regardless of the pinned chart version.

Files:
- `modules/database_operator/default/0.1/main.tf`
- `modules/mongodb_auth_operator/default/0.1/main.tf` (defensive — chart values already quay)

## Notes
- Chart source-of-truth fix is in the helm-charts PR; the in-place patch for already-running workloads is migration 113 in the facets-iac PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the database and MongoDB auth operators to use the explicitly specified kube-rbac-proxy image repository and tag.
  * Improves reliability by ensuring operator deployments consistently use the supported container image rather than chart defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->